### PR TITLE
feat(agent-loop): ADO client write operations for state and tag updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .cursor/
 temp-agent-loop.sh
 progress.txt
+.agent-context/

--- a/agent-loop/.agent-loop.example.json
+++ b/agent-loop/.agent-loop.example.json
@@ -1,0 +1,14 @@
+{
+  "org": "https://dev.azure.com/your-org",
+  "project": "Your Project",
+  "areaPath": "Your Project\\Your Team",
+  "team": "Your Project Team",
+  "process": "Scrum",
+  "repoUrl": "https://dev.azure.com/your-org/Your%20Project/_git/your-repo",
+  "baseBranch": "main",
+  "maxIterations": 50,
+  "provider": "anthropic",
+  "model": "claude-opus-4-6",
+  "workingDirectory": "/path/to/your/repo",
+  "featureId": 42
+}

--- a/agent-loop/.agent-loop.example.json
+++ b/agent-loop/.agent-loop.example.json
@@ -1,14 +1,14 @@
 {
-  "org": "https://dev.azure.com/your-org",
+  "organizationUrl": "https://dev.azure.com/your-org",
   "project": "Your Project",
   "areaPath": "Your Project\\Your Team",
   "team": "Your Project Team",
   "process": "Scrum",
-  "repoUrl": "https://dev.azure.com/your-org/Your%20Project/_git/your-repo",
-  "baseBranch": "main",
-  "maxIterations": 50,
-  "provider": "anthropic",
+  "repositoryUrl": "https://dev.azure.com/your-org/Your%20Project/_git/your-repo",
+  "baseBranch": null,
+  "maxIterationsPerPbi": 5,
+  "provider": "claude-code",
   "model": "claude-opus-4-6",
   "workingDirectory": "/path/to/your/repo",
-  "featureId": 42
+  "pollIntervalSeconds": 300
 }

--- a/agent-loop/.agent-loop.example.json
+++ b/agent-loop/.agent-loop.example.json
@@ -10,5 +10,6 @@
   "provider": "claude-code",
   "model": "claude-opus-4-6",
   "workingDirectory": "/path/to/your/repo",
+  "systemLogDirectory": "/path/to/system/log/directory",
   "pollIntervalSeconds": 300
 }

--- a/agent-loop/agent-loop.ps1
+++ b/agent-loop/agent-loop.ps1
@@ -375,6 +375,15 @@ function Get-WorkItem {
 }
 
 # Transitions a work item to the given state.
+# Returns the "in progress" state name for the configured process template.
+# Scrum → "In Progress"; Agile/CMMI → "Active"; unknown → "In Progress".
+function Get-InProgressState {
+    switch ($resolvedProcess) {
+        { $_ -in @('Agile', 'CMMI') } { return 'Active' }
+        default                        { return 'In Progress' }
+    }
+}
+
 # The caller is responsible for passing the correct state name for the process
 # template (e.g. "Active" for Agile, "In Progress" for Scrum).
 # Usage: Update-WorkItemState -WorkItemId <id> -State <state>
@@ -774,11 +783,12 @@ function Invoke-ProcessPbi {
 
     log_info "Starting inner loop for PBI ${PbiId}: $PbiTitle"
 
-    # Set PBI state to "In Progress" before first agent invocation.
+    # Set PBI state to the process-appropriate in-progress state before first agent invocation.
+    $inProgressState = Get-InProgressState
     try {
-        Update-WorkItemState -WorkItemId $PbiId -State 'In Progress'
+        Update-WorkItemState -WorkItemId $PbiId -State $inProgressState
     } catch {
-        log_error "Invoke-ProcessPbi: failed to set PBI $PbiId to 'In Progress' — aborting"
+        log_error "Invoke-ProcessPbi: failed to set PBI $PbiId to '$inProgressState' — aborting"
         return $false
     }
 

--- a/agent-loop/agent-loop.ps1
+++ b/agent-loop/agent-loop.ps1
@@ -62,6 +62,7 @@ param(
     [string] $Provider,
     [string] $Model,
     [string] $WorkingDirectory,
+    [string] $SystemLogDirectory,
     [string] $FeatureId
 )
 
@@ -78,13 +79,30 @@ function log_info {
 function log_warn {
     param([string]$Message)
     $ts = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss')
-    Write-Error "[$ts] [WARN] $Message"
+    Write-Warning "[$ts] [WARN] $Message"
 }
 
 function log_error {
     param([string]$Message)
     $ts = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss')
     Write-Error "[$ts] [ERROR] $Message"
+}
+
+function Get-DefaultSystemLogDirectory {
+    if ($IsMacOS) {
+        return (Join-Path $HOME 'Library/Logs/agent-loop')
+    }
+
+    if ($IsLinux) {
+        $stateHome = if ($env:XDG_STATE_HOME) { $env:XDG_STATE_HOME } else { Join-Path $HOME '.local/state' }
+        return (Join-Path $stateHome 'agent-loop/logs')
+    }
+
+    if ($env:LOCALAPPDATA) {
+        return (Join-Path $env:LOCALAPPDATA 'agent-loop/logs')
+    }
+
+    return (Join-Path $HOME '.agent-loop/logs')
 }
 
 # ── Load config file ──────────────────────────────────────────────────
@@ -114,6 +132,7 @@ if (Test-Path $configFile) {
         if ($null -ne $json.provider)        { $fileConfig['Provider']         = $json.provider }
         if ($null -ne $json.model)           { $fileConfig['Model']            = $json.model }
         if ($null -ne $json.workingDirectory) { $fileConfig['WorkingDirectory'] = $json.workingDirectory }
+        if ($null -ne $json.systemLogDirectory) { $fileConfig['SystemLogDirectory'] = $json.systemLogDirectory }
         if ($null -ne $json.featureId)       { $fileConfig['FeatureId']        = [string]$json.featureId }
     } catch {
         Write-Error "Error: Failed to parse ${configFile}: $_"
@@ -140,6 +159,15 @@ $resolvedMaxIterations  = Resolve-Value $MaxIterations 'MaxIterations' 5
 $resolvedProvider       = Resolve-Value $Provider      'Provider'
 $resolvedModel          = Resolve-Value $Model         'Model'
 $resolvedFeatureId      = Resolve-Value $FeatureId     'FeatureId'
+$resolvedSystemLogDir   = Resolve-Value $SystemLogDirectory 'SystemLogDirectory'
+
+if (-not $WorkingDirectory -and -not $env:AGENT_LOOP_WORKING_DIRECTORY -and $fileConfig.ContainsKey('WorkingDirectory') -and $fileConfig['WorkingDirectory']) {
+    $resolvedWorkingDir = $fileConfig['WorkingDirectory']
+}
+
+if (-not $resolvedSystemLogDir) {
+    $resolvedSystemLogDir = if ($env:AGENT_LOOP_SYSTEM_LOG_DIR) { $env:AGENT_LOOP_SYSTEM_LOG_DIR } else { Get-DefaultSystemLogDirectory }
+}
 
 # ── Validate required values ──────────────────────────────────────────
 $errors = [System.Collections.Generic.List[string]]::new()
@@ -164,6 +192,24 @@ if ($resolvedProvider -notin @('claude-code', 'cursor-cli')) {
     Write-Host "Error: Invalid provider '$resolvedProvider'. Must be 'claude-code' or 'cursor-cli'." -ForegroundColor Red
     exit 1
 }
+
+if ($resolvedMaxIterations -lt 1) {
+    Write-Host 'Error: -MaxIterations must be a positive integer.' -ForegroundColor Red
+    exit 1
+}
+
+if (-not (Test-Path $resolvedWorkingDir -PathType Container)) {
+    Write-Host "Error: working directory does not exist: $resolvedWorkingDir" -ForegroundColor Red
+    exit 1
+}
+
+$resolvedWorkingDir = (Resolve-Path $resolvedWorkingDir).Path
+
+if (-not (Test-Path $resolvedSystemLogDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $resolvedSystemLogDir -Force | Out-Null
+}
+
+$resolvedSystemLogDir = (Resolve-Path $resolvedSystemLogDir).Path
 
 # ── Validate environment variables ───────────────────────────────────
 $envErrors = [System.Collections.Generic.List[string]]::new()
@@ -200,6 +246,7 @@ $env:AGENT_LOOP_MAX_ITERATIONS    = $resolvedMaxIterations
 $env:AGENT_LOOP_PROVIDER          = $resolvedProvider
 $env:AGENT_LOOP_MODEL             = $resolvedModel
 $env:AGENT_LOOP_WORKING_DIRECTORY = $resolvedWorkingDir
+$env:AGENT_LOOP_SYSTEM_LOG_DIR    = $resolvedSystemLogDir
 $env:AGENT_LOOP_FEATURE_ID        = $resolvedFeatureId
 
 $modelLabel = if ($resolvedModel) { " ($resolvedModel)" } else { '' }
@@ -217,25 +264,32 @@ if ($resolvedFeatureId) { Write-Host "  Feature ID:      $resolvedFeatureId" }
 if ($resolvedAreaPath)  { Write-Host "  Area path:       $resolvedAreaPath" }
 if ($resolvedTeam)      { Write-Host "  Team:            $resolvedTeam" }
 if ($resolvedRepoUrl)   { Write-Host "  Repo URL:        $resolvedRepoUrl" }
+Write-Host "  System logs:     $resolvedSystemLogDir"
 Write-Host ('=' * 54)
 
 # ── Lock manager ──────────────────────────────────────────────────────
 $lockFile = Join-Path $resolvedWorkingDir '.agent-loop.lock'
+$script:lockAcquired = $false
 
 function Acquire-Lock {
     try {
         $stream = [System.IO.File]::Open($lockFile, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
-        $stream.Close()
+        $writer = [System.IO.StreamWriter]::new($stream)
+        $writer.Write([string]$PID)
+        $writer.Flush()
+        $writer.Dispose()
         $stream.Dispose()
     } catch {
         log_warn "Another instance is already running (lock file exists: $lockFile). Exiting."
-        exit 0
+        return $false
     }
+    $script:lockAcquired = $true
     log_info "Lock acquired: $lockFile"
+    return $true
 }
 
 function Release-Lock {
-    if (Test-Path $lockFile) {
+    if ($script:lockAcquired -and (Test-Path $lockFile) -and ((Get-Content $lockFile -Raw).Trim() -eq [string]$PID)) {
         Remove-Item -Force $lockFile
         log_info "Lock released: $lockFile"
     }
@@ -243,6 +297,7 @@ function Release-Lock {
 
 # ── Context manager ───────────────────────────────────────────────────
 $agentContextDir = Join-Path $resolvedWorkingDir '.agent-context'
+$script:currentFeatureLogFile = $null
 
 function Ensure-Gitignore {
     $gitignore = Join-Path $resolvedWorkingDir '.gitignore'
@@ -267,6 +322,31 @@ function Capture-AgentLog {
     $logsDir = Join-Path $agentContextDir 'logs'
     if (-not (Test-Path $logsDir)) { New-Item -ItemType Directory -Path $logsDir -Force | Out-Null }
     Add-Content -Path (Join-Path $logsDir "feature-${FeatureId}.log") -Value $Output
+    if ($script:currentFeatureLogFile) {
+        Add-Content -Path $script:currentFeatureLogFile -Value $Output
+    }
+}
+
+function Start-FeatureLog {
+    param([string]$FeatureId, [string]$FeatureTitle)
+    $timestamp = (Get-Date).ToUniversalTime().ToString('yyyyMMddTHHmmssZ')
+    $script:currentFeatureLogFile = Join-Path $resolvedSystemLogDir "feature-${FeatureId}-${timestamp}.log"
+    @(
+        "Feature ID: $FeatureId"
+        "Feature Title: $FeatureTitle"
+        "Started At (UTC): $((Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss'))"
+        "Working Directory: $resolvedWorkingDir"
+        "Provider: $resolvedProvider$((if ($resolvedModel) { " ($resolvedModel)" } else { '' }))"
+        ''
+    ) | Set-Content -Path $script:currentFeatureLogFile
+    log_info "Persistent agent log: $($script:currentFeatureLogFile)"
+}
+
+function Add-FeatureLogNote {
+    param([string]$Message)
+    if ($script:currentFeatureLogFile) {
+        Add-Content -Path $script:currentFeatureLogFile -Value "[$((Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss'))] $Message"
+    }
 }
 
 function Invoke-Cleanup {
@@ -306,8 +386,8 @@ function Invoke-AdoApi {
             return Invoke-RestMethod -Method $Method -Uri $Url -Headers $headers
         }
     } catch {
-        $statusCode = $_.Exception.Response.StatusCode.value__
-        $errorBody  = $_.ErrorDetails.Message
+        $statusCode = if ($_.Exception.Response) { $_.Exception.Response.StatusCode.value__ } else { 'n/a' }
+        $errorBody  = if ($_.ErrorDetails -and $_.ErrorDetails.Message) { $_.ErrorDetails.Message } else { $_.Exception.Message }
         log_error "ADO API error: HTTP $statusCode — $Method $Url"
         log_error "Response: $errorBody"
         throw
@@ -320,7 +400,8 @@ function Invoke-AdoApi {
 function Get-EligibleFeatures {
     $wiql = "SELECT [System.Id] FROM WorkItemLinks WHERE [Source].[System.WorkItemType] = 'Feature'"
     if ($resolvedAreaPath) {
-        $wiql += " AND [Source].[System.AreaPath] UNDER '$resolvedAreaPath'"
+        $escapedAreaPath = $resolvedAreaPath -replace "'", "''"
+        $wiql += " AND [Source].[System.AreaPath] UNDER '$escapedAreaPath'"
     }
     $wiql += " AND [Target].[System.Tags] CONTAINS 'ready-for-agent' AND [Target].[System.State] = 'New' AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' MODE (MustContain)"
 
@@ -397,7 +478,7 @@ function Update-WorkItemState {
         [string] $State
     )
     $patchDoc = @(
-        @{ op = 'add'; path = '/fields/System.State'; value = $State }
+        @{ op = 'replace'; path = '/fields/System.State'; value = $State }
     ) | ConvertTo-Json -Compress
     $url = "$resolvedOrg/$resolvedProject/_apis/wit/workitems/${WorkItemId}?api-version=7.1"
     Invoke-AdoApi -Method PATCH -Url $url -Body $patchDoc -ContentType 'application/json-patch+json' | Out-Null
@@ -414,10 +495,16 @@ function Add-WorkItemTag {
     # Fetch current tags so we can append rather than overwrite.
     $workItem    = Get-WorkItem -WorkItemId $WorkItemId
     $currentTags = $workItem.fields.'System.Tags'
+    $tagList     = if ($currentTags) { @($currentTags -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }) } else { @() }
+    if ($tagList -contains $Tag) {
+        log_info "Tag '$Tag' already present on work item $WorkItemId"
+        return
+    }
     $newTags     = if ($currentTags) { "$currentTags; $Tag" } else { $Tag }
+    $op          = if ($currentTags) { 'replace' } else { 'add' }
 
     $patchDoc = @(
-        @{ op = 'add'; path = '/fields/System.Tags'; value = $newTags }
+        @{ op = $op; path = '/fields/System.Tags'; value = $newTags }
     ) | ConvertTo-Json -Compress
     $url = "$resolvedOrg/$resolvedProject/_apis/wit/workitems/${WorkItemId}?api-version=7.1"
     Invoke-AdoApi -Method PATCH -Url $url -Body $patchDoc -ContentType 'application/json-patch+json' | Out-Null
@@ -726,20 +813,20 @@ function Invoke-Agent {
                     --output-format json `
                     @modelArgs `
                     --allowedTools 'Read,Write,Edit,Bash' 2>&1 | Out-String
+                $exitCode = $LASTEXITCODE
             } catch {
                 $output   = $_.Exception.Message
                 $exitCode = 1
             }
-            $exitCode = $LASTEXITCODE
         }
         'cursor-cli' {
             try {
                 $output = & agent -p $Prompt --force --output-format json 2>&1 | Out-String
+                $exitCode = $LASTEXITCODE
             } catch {
                 $output   = $_.Exception.Message
                 $exitCode = 1
             }
-            $exitCode = $LASTEXITCODE
         }
         default {
             $msg = "Invoke-Agent: unknown provider '$resolvedProvider'. Must be 'claude-code' or 'cursor-cli'."
@@ -748,7 +835,7 @@ function Invoke-Agent {
         }
     }
 
-    $completed = $output -match 'AGENT_COMPLETE'
+    $completed = $output -match '(?m)^AGENT_COMPLETE$'
 
     if ($exitCode -ne 0) {
         log_error "Invoke-Agent: agent exited with non-zero exit code $exitCode"
@@ -825,12 +912,17 @@ function Invoke-ProcessPbi {
 }
 
 try {
-    Acquire-Lock
+    Set-Location $resolvedWorkingDir
+
+    if (-not (Acquire-Lock)) {
+        exit 0
+    }
     Ensure-Gitignore
 
     # Resolve base branch early (auto-detect if not configured) so it is
     # available to both New-FeatureBranch and New-PullRequest.
     $resolvedBaseBranch = Get-DefaultBranch
+    $env:AGENT_LOOP_BASE_BRANCH = $resolvedBaseBranch
     log_info "Base branch resolved to '$resolvedBaseBranch'"
 
     # ── Orchestrator ──────────────────────────────────────────────────────
@@ -856,10 +948,18 @@ try {
         $featureJson = Get-WorkItem -WorkItemId $featureId
     }
 
+    $featureType = [string]$featureJson.fields.'System.WorkItemType'
+    if ($featureType -ne 'Feature') {
+        log_error "Work item $featureId is a '$featureType', not a Feature"
+        exit 1
+    }
+
     $featureTitle       = $featureJson.fields.'System.Title'
     $featureDescription = $featureJson.fields.'System.Description'
 
     log_info "Processing Feature ${featureId}: $featureTitle"
+    Start-FeatureLog -FeatureId $featureId -FeatureTitle $featureTitle
+    Add-FeatureLogNote -Message 'Feature processing started'
 
     # Step 5: Fetch all child PBIs
     log_info "Fetching child PBIs for Feature $featureId"
@@ -867,9 +967,13 @@ try {
 
     # Filter to only PBIs tagged "ready-for-agent" in "New" state.
     $pbis = @($pbis | Where-Object {
-        $tags  = $_.fields.'System.Tags'
+        $tagList = if ($_.fields.'System.Tags') {
+            @($_.fields.'System.Tags' -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+        } else {
+            @()
+        }
         $state = $_.fields.'System.State'
-        ($tags -and $tags -match 'ready-for-agent') -and ($state -eq 'New')
+        (($tagList -contains 'ready-for-agent') -and ($state -eq 'New'))
     })
 
     if ($pbis.Count -eq 0) {
@@ -920,10 +1024,17 @@ try {
     # Step 11: Create PR only when all PBIs are tagged agent-done
     if ($featureSuccess) {
         log_info "All PBIs completed — creating pull request for Feature $featureId"
-        $prUrl = New-PullRequest -FeatureTitle $featureTitle -FeatureBranch $featureBranch -Pbis $sortedPbis
+        try {
+            $prUrl = New-PullRequest -FeatureTitle $featureTitle -FeatureBranch $featureBranch -Pbis $sortedPbis
+        } catch {
+            Add-FeatureLogNote -Message 'Failed to create pull request'
+            throw
+        }
+        Add-FeatureLogNote -Message "Feature completed successfully. Pull request: $prUrl"
         log_info "Feature $featureId complete — PR: $prUrl"
         exit 0
     } else {
+        Add-FeatureLogNote -Message 'Feature processing failed'
         log_error "Feature $featureId processing failed — one or more PBIs did not complete"
         exit 1
     }

--- a/agent-loop/agent-loop.ps1
+++ b/agent-loop/agent-loop.ps1
@@ -25,10 +25,10 @@
   Git repository URL
 
 .PARAMETER BaseBranch
-  Base branch to branch from (default: main)
+  Base branch (auto-detected from git if omitted)
 
 .PARAMETER MaxIterations
-  Maximum loop iterations (default: 50)
+  Max agent invocations per PBI (default: 5)
 
 .PARAMETER Provider
   AI provider: claude-code or cursor-cli
@@ -45,8 +45,8 @@
 .NOTES
   Required environment variables:
     AZURE_DEVOPS_PAT     — Azure DevOps Personal Access Token
-    ANTHROPIC_API_KEY    — Required when -Provider is anthropic
-    CURSOR_API_KEY       — Required when -Provider is cursor
+    ANTHROPIC_API_KEY    — Required when -Provider is claude-code
+    CURSOR_API_KEY       — Required when -Provider is cursor-cli
 #>
 
 [CmdletBinding()]
@@ -103,18 +103,18 @@ $fileConfig = @{}
 if (Test-Path $configFile) {
     try {
         $json = Get-Content $configFile -Raw | ConvertFrom-Json
-        if ($null -ne $json.org)              { $fileConfig['Org']              = $json.org }
-        if ($null -ne $json.project)          { $fileConfig['Project']          = $json.project }
-        if ($null -ne $json.areaPath)         { $fileConfig['AreaPath']         = $json.areaPath }
-        if ($null -ne $json.team)             { $fileConfig['Team']             = $json.team }
-        if ($null -ne $json.process)          { $fileConfig['Process']          = $json.process }
-        if ($null -ne $json.repoUrl)          { $fileConfig['RepoUrl']          = $json.repoUrl }
-        if ($null -ne $json.baseBranch)       { $fileConfig['BaseBranch']       = $json.baseBranch }
-        if ($null -ne $json.maxIterations)    { $fileConfig['MaxIterations']    = $json.maxIterations }
-        if ($null -ne $json.provider)         { $fileConfig['Provider']         = $json.provider }
-        if ($null -ne $json.model)            { $fileConfig['Model']            = $json.model }
+        if ($null -ne $json.organizationUrl) { $fileConfig['Org']              = $json.organizationUrl }
+        if ($null -ne $json.project)         { $fileConfig['Project']          = $json.project }
+        if ($null -ne $json.areaPath)        { $fileConfig['AreaPath']         = $json.areaPath }
+        if ($null -ne $json.team)            { $fileConfig['Team']             = $json.team }
+        if ($null -ne $json.process)         { $fileConfig['Process']          = $json.process }
+        if ($null -ne $json.repositoryUrl)   { $fileConfig['RepoUrl']          = $json.repositoryUrl }
+        if ($null -ne $json.baseBranch)      { $fileConfig['BaseBranch']       = $json.baseBranch }
+        if ($null -ne $json.maxIterationsPerPbi) { $fileConfig['MaxIterations'] = $json.maxIterationsPerPbi }
+        if ($null -ne $json.provider)        { $fileConfig['Provider']         = $json.provider }
+        if ($null -ne $json.model)           { $fileConfig['Model']            = $json.model }
         if ($null -ne $json.workingDirectory) { $fileConfig['WorkingDirectory'] = $json.workingDirectory }
-        if ($null -ne $json.featureId)        { $fileConfig['FeatureId']        = [string]$json.featureId }
+        if ($null -ne $json.featureId)       { $fileConfig['FeatureId']        = [string]$json.featureId }
     } catch {
         Write-Error "Error: Failed to parse ${configFile}: $_"
         exit 1
@@ -135,8 +135,8 @@ $resolvedAreaPath       = Resolve-Value $AreaPath      'AreaPath'
 $resolvedTeam           = Resolve-Value $Team          'Team'
 $resolvedProcess        = Resolve-Value $Process       'Process'
 $resolvedRepoUrl        = Resolve-Value $RepoUrl       'RepoUrl'
-$resolvedBaseBranch     = Resolve-Value $BaseBranch    'BaseBranch'    'main'
-$resolvedMaxIterations  = Resolve-Value $MaxIterations 'MaxIterations' 50
+$resolvedBaseBranch     = Resolve-Value $BaseBranch    'BaseBranch'    $null
+$resolvedMaxIterations  = Resolve-Value $MaxIterations 'MaxIterations' 5
 $resolvedProvider       = Resolve-Value $Provider      'Provider'
 $resolvedModel          = Resolve-Value $Model         'Model'
 $resolvedFeatureId      = Resolve-Value $FeatureId     'FeatureId'
@@ -204,13 +204,15 @@ $env:AGENT_LOOP_FEATURE_ID        = $resolvedFeatureId
 
 $modelLabel = if ($resolvedModel) { " ($resolvedModel)" } else { '' }
 
+$baseBranchLabel = if ($resolvedBaseBranch) { $resolvedBaseBranch } else { '(auto-detect)' }
+
 Write-Host ('=' * 54)
 Write-Host '  agent-loop'
 Write-Host "  Org:             $resolvedOrg"
 Write-Host "  Project:         $resolvedProject"
 Write-Host "  Provider:        ${resolvedProvider}${modelLabel}"
-Write-Host "  Base branch:     $resolvedBaseBranch"
-Write-Host "  Max iterations:  $resolvedMaxIterations"
+Write-Host "  Base branch:     $baseBranchLabel"
+Write-Host "  Max iter/PBI:    $resolvedMaxIterations"
 if ($resolvedFeatureId) { Write-Host "  Feature ID:      $resolvedFeatureId" }
 if ($resolvedAreaPath)  { Write-Host "  Area path:       $resolvedAreaPath" }
 if ($resolvedTeam)      { Write-Host "  Team:            $resolvedTeam" }
@@ -244,10 +246,12 @@ $agentContextDir = Join-Path $resolvedWorkingDir '.agent-context'
 
 function Ensure-Gitignore {
     $gitignore = Join-Path $resolvedWorkingDir '.gitignore'
-    $entry = '.agent-context/'
-    if (-not (Test-Path $gitignore) -or -not (Get-Content $gitignore -Raw).Contains($entry)) {
-        Add-Content -Path $gitignore -Value $entry
-        log_info ".agent-context/ added to .gitignore"
+    $entries = @('.agent-context/', '.agent-loop.lock')
+    foreach ($entry in $entries) {
+        if (-not (Test-Path $gitignore) -or -not (Get-Content $gitignore -Raw).Contains($entry)) {
+            Add-Content -Path $gitignore -Value $entry
+            log_info "$entry added to .gitignore"
+        }
     }
 }
 
@@ -721,8 +725,7 @@ function Invoke-Agent {
                 $output = & claude -p $Prompt `
                     --output-format json `
                     @modelArgs `
-                    --allowedTools 'Read,Write,Edit,Bash' `
-                    --max-turns $resolvedMaxIterations 2>&1 | Out-String
+                    --allowedTools 'Read,Write,Edit,Bash' 2>&1 | Out-String
             } catch {
                 $output   = $_.Exception.Message
                 $exitCode = 1
@@ -825,6 +828,11 @@ try {
     Acquire-Lock
     Ensure-Gitignore
 
+    # Resolve base branch early (auto-detect if not configured) so it is
+    # available to both New-FeatureBranch and New-PullRequest.
+    $resolvedBaseBranch = Get-DefaultBranch
+    log_info "Base branch resolved to '$resolvedBaseBranch'"
+
     # ── Orchestrator ──────────────────────────────────────────────────────
 
     log_info "agent-loop started"
@@ -857,11 +865,18 @@ try {
     log_info "Fetching child PBIs for Feature $featureId"
     $pbis = @(Get-ChildPbis -FeatureId $featureId)
 
+    # Filter to only PBIs tagged "ready-for-agent" in "New" state.
+    $pbis = @($pbis | Where-Object {
+        $tags  = $_.fields.'System.Tags'
+        $state = $_.fields.'System.State'
+        ($tags -and $tags -match 'ready-for-agent') -and ($state -eq 'New')
+    })
+
     if ($pbis.Count -eq 0) {
-        log_info "Feature $featureId has no child PBIs — nothing to do"
+        log_info "Feature $featureId has no eligible child PBIs (ready-for-agent + New) — nothing to do"
         exit 0
     }
-    log_info "Found $($pbis.Count) PBI(s) for Feature $featureId"
+    log_info "Found $($pbis.Count) eligible PBI(s) for Feature $featureId"
 
     # Step 6: Topologically sort PBIs by dependency
     log_info "Sorting PBIs by dependency order"

--- a/agent-loop/agent-loop.ps1
+++ b/agent-loop/agent-loop.ps1
@@ -1,0 +1,908 @@
+<#
+.SYNOPSIS
+  agent-loop.ps1 — Autonomous ADO feature implementation loop.
+
+.DESCRIPTION
+  Reads config from .agent-loop.json in the working directory and/or
+  CLI parameters (CLI wins). Validates all required values before running.
+
+.PARAMETER Org
+  Azure DevOps org URL (e.g. https://dev.azure.com/contoso)
+
+.PARAMETER Project
+  Azure DevOps project name
+
+.PARAMETER AreaPath
+  Work item area path (e.g. "MyProject\Team A")
+
+.PARAMETER Team
+  Azure DevOps team name
+
+.PARAMETER Process
+  Process template: Scrum, Agile, or CMMI
+
+.PARAMETER RepoUrl
+  Git repository URL
+
+.PARAMETER BaseBranch
+  Base branch to branch from (default: main)
+
+.PARAMETER MaxIterations
+  Maximum loop iterations (default: 50)
+
+.PARAMETER Provider
+  AI provider: claude-code or cursor-cli
+
+.PARAMETER Model
+  Model ID to use (e.g. claude-opus-4-6)
+
+.PARAMETER WorkingDirectory
+  Working directory containing the repo
+
+.PARAMETER FeatureId
+  ADO Feature ID to process (optional; processes all if omitted)
+
+.NOTES
+  Required environment variables:
+    AZURE_DEVOPS_PAT     — Azure DevOps Personal Access Token
+    ANTHROPIC_API_KEY    — Required when -Provider is anthropic
+    CURSOR_API_KEY       — Required when -Provider is cursor
+#>
+
+[CmdletBinding()]
+param(
+    [string] $Org,
+    [string] $Project,
+    [string] $AreaPath,
+    [string] $Team,
+    [string] $Process,
+    [string] $RepoUrl,
+    [string] $BaseBranch,
+    [int]    $MaxIterations,
+    [string] $Provider,
+    [string] $Model,
+    [string] $WorkingDirectory,
+    [string] $FeatureId
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ── Logging ───────────────────────────────────────────────────────────
+function log_info {
+    param([string]$Message)
+    $ts = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss')
+    Write-Host "[$ts] [INFO] $Message"
+}
+
+function log_warn {
+    param([string]$Message)
+    $ts = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss')
+    Write-Error "[$ts] [WARN] $Message"
+}
+
+function log_error {
+    param([string]$Message)
+    $ts = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss')
+    Write-Error "[$ts] [ERROR] $Message"
+}
+
+# ── Load config file ──────────────────────────────────────────────────
+# Resolve working directory: param > env > current directory
+$resolvedWorkingDir = if ($WorkingDirectory) {
+    $WorkingDirectory
+} elseif ($env:AGENT_LOOP_WORKING_DIRECTORY) {
+    $env:AGENT_LOOP_WORKING_DIRECTORY
+} else {
+    (Get-Location).Path
+}
+
+$configFile = Join-Path $resolvedWorkingDir '.agent-loop.json'
+$fileConfig = @{}
+
+if (Test-Path $configFile) {
+    try {
+        $json = Get-Content $configFile -Raw | ConvertFrom-Json
+        if ($null -ne $json.org)              { $fileConfig['Org']              = $json.org }
+        if ($null -ne $json.project)          { $fileConfig['Project']          = $json.project }
+        if ($null -ne $json.areaPath)         { $fileConfig['AreaPath']         = $json.areaPath }
+        if ($null -ne $json.team)             { $fileConfig['Team']             = $json.team }
+        if ($null -ne $json.process)          { $fileConfig['Process']          = $json.process }
+        if ($null -ne $json.repoUrl)          { $fileConfig['RepoUrl']          = $json.repoUrl }
+        if ($null -ne $json.baseBranch)       { $fileConfig['BaseBranch']       = $json.baseBranch }
+        if ($null -ne $json.maxIterations)    { $fileConfig['MaxIterations']    = $json.maxIterations }
+        if ($null -ne $json.provider)         { $fileConfig['Provider']         = $json.provider }
+        if ($null -ne $json.model)            { $fileConfig['Model']            = $json.model }
+        if ($null -ne $json.workingDirectory) { $fileConfig['WorkingDirectory'] = $json.workingDirectory }
+        if ($null -ne $json.featureId)        { $fileConfig['FeatureId']        = [string]$json.featureId }
+    } catch {
+        Write-Error "Error: Failed to parse ${configFile}: $_"
+        exit 1
+    }
+}
+
+# ── Merge: CLI wins over config file ─────────────────────────────────
+function Resolve-Value {
+    param($cliValue, $configKey, $default = $null)
+    if ($cliValue -and $cliValue -ne 0) { return $cliValue }
+    if ($fileConfig.ContainsKey($configKey) -and $fileConfig[$configKey]) { return $fileConfig[$configKey] }
+    return $default
+}
+
+$resolvedOrg            = Resolve-Value $Org           'Org'
+$resolvedProject        = Resolve-Value $Project       'Project'
+$resolvedAreaPath       = Resolve-Value $AreaPath      'AreaPath'
+$resolvedTeam           = Resolve-Value $Team          'Team'
+$resolvedProcess        = Resolve-Value $Process       'Process'
+$resolvedRepoUrl        = Resolve-Value $RepoUrl       'RepoUrl'
+$resolvedBaseBranch     = Resolve-Value $BaseBranch    'BaseBranch'    'main'
+$resolvedMaxIterations  = Resolve-Value $MaxIterations 'MaxIterations' 50
+$resolvedProvider       = Resolve-Value $Provider      'Provider'
+$resolvedModel          = Resolve-Value $Model         'Model'
+$resolvedFeatureId      = Resolve-Value $FeatureId     'FeatureId'
+
+# ── Validate required values ──────────────────────────────────────────
+$errors = [System.Collections.Generic.List[string]]::new()
+
+if (-not $resolvedOrg)      { $errors.Add('Missing required value: -Org (Azure DevOps org URL)') }
+if (-not $resolvedProject)  { $errors.Add('Missing required value: -Project (Azure DevOps project name)') }
+if (-not $resolvedProvider) { $errors.Add('Missing required value: -Provider (claude-code or cursor-cli)') }
+
+if ($errors.Count -gt 0) {
+    Write-Host 'Error: Configuration is incomplete:' -ForegroundColor Red
+    foreach ($err in $errors) {
+        Write-Host "  - $err" -ForegroundColor Red
+    }
+    Write-Host ''
+    Write-Host 'Provide values via CLI parameters or .agent-loop.json in the working directory.' -ForegroundColor Yellow
+    Write-Host 'See .agent-loop.example.json for the full schema.' -ForegroundColor Yellow
+    exit 1
+}
+
+# ── Validate provider value ───────────────────────────────────────────
+if ($resolvedProvider -notin @('claude-code', 'cursor-cli')) {
+    Write-Host "Error: Invalid provider '$resolvedProvider'. Must be 'claude-code' or 'cursor-cli'." -ForegroundColor Red
+    exit 1
+}
+
+# ── Validate environment variables ───────────────────────────────────
+$envErrors = [System.Collections.Generic.List[string]]::new()
+
+if (-not $env:AZURE_DEVOPS_PAT) {
+    $envErrors.Add('Missing required environment variable: AZURE_DEVOPS_PAT')
+}
+
+if ($resolvedProvider -eq 'claude-code' -and -not $env:ANTHROPIC_API_KEY) {
+    $envErrors.Add('Missing required environment variable: ANTHROPIC_API_KEY (required for provider=claude-code)')
+}
+
+if ($resolvedProvider -eq 'cursor-cli' -and -not $env:CURSOR_API_KEY) {
+    $envErrors.Add('Missing required environment variable: CURSOR_API_KEY (required for provider=cursor-cli)')
+}
+
+if ($envErrors.Count -gt 0) {
+    Write-Host 'Error: Required environment variables are not set:' -ForegroundColor Red
+    foreach ($err in $envErrors) {
+        Write-Host "  - $err" -ForegroundColor Red
+    }
+    exit 1
+}
+
+# ── Export resolved config for use by the rest of the script ─────────
+$env:AGENT_LOOP_ORG               = $resolvedOrg
+$env:AGENT_LOOP_PROJECT           = $resolvedProject
+$env:AGENT_LOOP_AREA_PATH         = $resolvedAreaPath
+$env:AGENT_LOOP_TEAM              = $resolvedTeam
+$env:AGENT_LOOP_PROCESS           = $resolvedProcess
+$env:AGENT_LOOP_REPO_URL          = $resolvedRepoUrl
+$env:AGENT_LOOP_BASE_BRANCH       = $resolvedBaseBranch
+$env:AGENT_LOOP_MAX_ITERATIONS    = $resolvedMaxIterations
+$env:AGENT_LOOP_PROVIDER          = $resolvedProvider
+$env:AGENT_LOOP_MODEL             = $resolvedModel
+$env:AGENT_LOOP_WORKING_DIRECTORY = $resolvedWorkingDir
+$env:AGENT_LOOP_FEATURE_ID        = $resolvedFeatureId
+
+$modelLabel = if ($resolvedModel) { " ($resolvedModel)" } else { '' }
+
+Write-Host ('=' * 54)
+Write-Host '  agent-loop'
+Write-Host "  Org:             $resolvedOrg"
+Write-Host "  Project:         $resolvedProject"
+Write-Host "  Provider:        ${resolvedProvider}${modelLabel}"
+Write-Host "  Base branch:     $resolvedBaseBranch"
+Write-Host "  Max iterations:  $resolvedMaxIterations"
+if ($resolvedFeatureId) { Write-Host "  Feature ID:      $resolvedFeatureId" }
+if ($resolvedAreaPath)  { Write-Host "  Area path:       $resolvedAreaPath" }
+if ($resolvedTeam)      { Write-Host "  Team:            $resolvedTeam" }
+if ($resolvedRepoUrl)   { Write-Host "  Repo URL:        $resolvedRepoUrl" }
+Write-Host ('=' * 54)
+
+# ── Lock manager ──────────────────────────────────────────────────────
+$lockFile = Join-Path $resolvedWorkingDir '.agent-loop.lock'
+
+function Acquire-Lock {
+    try {
+        $stream = [System.IO.File]::Open($lockFile, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        $stream.Close()
+        $stream.Dispose()
+    } catch {
+        log_warn "Another instance is already running (lock file exists: $lockFile). Exiting."
+        exit 0
+    }
+    log_info "Lock acquired: $lockFile"
+}
+
+function Release-Lock {
+    if (Test-Path $lockFile) {
+        Remove-Item -Force $lockFile
+        log_info "Lock released: $lockFile"
+    }
+}
+
+# ── Context manager ───────────────────────────────────────────────────
+$agentContextDir = Join-Path $resolvedWorkingDir '.agent-context'
+
+function Ensure-Gitignore {
+    $gitignore = Join-Path $resolvedWorkingDir '.gitignore'
+    $entry = '.agent-context/'
+    if (-not (Test-Path $gitignore) -or -not (Get-Content $gitignore -Raw).Contains($entry)) {
+        Add-Content -Path $gitignore -Value $entry
+        log_info ".agent-context/ added to .gitignore"
+    }
+}
+
+function Write-FeatureContext {
+    param([string]$FeatureId, [string]$Content)
+    if (-not (Test-Path $agentContextDir)) { New-Item -ItemType Directory -Path $agentContextDir -Force | Out-Null }
+    Set-Content -Path (Join-Path $agentContextDir 'feature.md') -Value $Content -NoNewline
+    log_info "Feature context written to .agent-context/feature.md (feature $FeatureId)"
+}
+
+function Capture-AgentLog {
+    param([string]$FeatureId, [string]$Output)
+    $logsDir = Join-Path $agentContextDir 'logs'
+    if (-not (Test-Path $logsDir)) { New-Item -ItemType Directory -Path $logsDir -Force | Out-Null }
+    Add-Content -Path (Join-Path $logsDir "feature-${FeatureId}.log") -Value $Output
+}
+
+function Invoke-Cleanup {
+    if (Test-Path $agentContextDir) {
+        Remove-Item -Recurse -Force $agentContextDir
+        log_info "Cleaned up .agent-context/"
+    }
+}
+
+# ── ADO Client ────────────────────────────────────────────────────────
+
+# Returns the "Basic <base64(:PAT)>" header value for ADO REST calls.
+function Get-AdoAuthHeader {
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes(":$($env:AZURE_DEVOPS_PAT)")
+    return "Basic $([Convert]::ToBase64String($bytes))"
+}
+
+# Makes an ADO REST API call.
+# Returns the deserialized response on success (HTTP 2xx).
+# Logs an error and re-throws on failure.
+# Usage: Invoke-AdoApi -Method GET|POST -Url <url> [-Body <json>] [-ContentType <type>]
+function Invoke-AdoApi {
+    param(
+        [string] $Method,
+        [string] $Url,
+        [string] $Body = $null,
+        [string] $ContentType = 'application/json'
+    )
+    $headers = @{
+        'Authorization' = Get-AdoAuthHeader
+        'Content-Type'  = $ContentType
+    }
+    try {
+        if ($Body) {
+            return Invoke-RestMethod -Method $Method -Uri $Url -Headers $headers -Body $Body
+        } else {
+            return Invoke-RestMethod -Method $Method -Uri $Url -Headers $headers
+        }
+    } catch {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        $errorBody  = $_.ErrorDetails.Message
+        log_error "ADO API error: HTTP $statusCode — $Method $Url"
+        log_error "Response: $errorBody"
+        throw
+    }
+}
+
+# Queries ADO for Features that have at least one child PBI tagged
+# "ready-for-agent" in "New" state, scoped to the configured AreaPath.
+# Returns an array of Feature IDs (integers).
+function Get-EligibleFeatures {
+    $wiql = "SELECT [System.Id] FROM WorkItemLinks WHERE [Source].[System.WorkItemType] = 'Feature'"
+    if ($resolvedAreaPath) {
+        $wiql += " AND [Source].[System.AreaPath] UNDER '$resolvedAreaPath'"
+    }
+    $wiql += " AND [Target].[System.Tags] CONTAINS 'ready-for-agent' AND [Target].[System.State] = 'New' AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' MODE (MustContain)"
+
+    $url  = "$resolvedOrg/$resolvedProject/_apis/wit/wiql?api-version=7.1"
+    $body = @{ query = $wiql } | ConvertTo-Json -Compress
+
+    $response = Invoke-AdoApi -Method POST -Url $url -Body $body
+
+    # Extract unique source Feature IDs (source is $null for the root row; skip it).
+    return @(
+        $response.workItemRelations |
+        Where-Object { $null -ne $_.source } |
+        ForEach-Object { $_.source.id } |
+        Select-Object -Unique
+    )
+}
+
+# Fetches all child PBIs of a Feature, expanding all fields and relations
+# (including Dependency-Forward links needed by the dependency resolver).
+# Returns an array of work item objects.
+# Usage: Get-ChildPbis -FeatureId <id>
+function Get-ChildPbis {
+    param([string] $FeatureId)
+
+    # Fetch the Feature to get its relations.
+    $featureUrl = "$resolvedOrg/$resolvedProject/_apis/wit/workitems/${FeatureId}?`$expand=relations&api-version=7.1"
+    $feature    = Invoke-AdoApi -Method GET -Url $featureUrl
+
+    # Extract IDs of direct children (Hierarchy-Forward from Feature to PBI).
+    $childIds = @(
+        ($feature.relations ?? @()) |
+        Where-Object { $_.rel -eq 'System.LinkTypes.Hierarchy-Forward' } |
+        ForEach-Object { ($_.url -split '/')[-1] }
+    )
+
+    if ($childIds.Count -eq 0) {
+        log_info "No child PBIs found for Feature $FeatureId"
+        return @()
+    }
+
+    $idsParam = $childIds -join ','
+    # Fetch all child PBIs with full expansion (fields + relations).
+    $pbisUrl  = "$resolvedOrg/$resolvedProject/_apis/wit/workitems?ids=$idsParam&`$expand=all&api-version=7.1"
+    $response = Invoke-AdoApi -Method GET -Url $pbisUrl
+
+    return $response.value
+}
+
+# Fetches a single work item by ID with all fields and relations expanded.
+# Returns the work item object.
+# Usage: Get-WorkItem -WorkItemId <id>
+function Get-WorkItem {
+    param([string] $WorkItemId)
+    $url = "$resolvedOrg/$resolvedProject/_apis/wit/workitems/${WorkItemId}?`$expand=all&api-version=7.1"
+    return Invoke-AdoApi -Method GET -Url $url
+}
+
+# Transitions a work item to the given state.
+# The caller is responsible for passing the correct state name for the process
+# template (e.g. "Active" for Agile, "In Progress" for Scrum).
+# Usage: Update-WorkItemState -WorkItemId <id> -State <state>
+function Update-WorkItemState {
+    param(
+        [string] $WorkItemId,
+        [string] $State
+    )
+    $patchDoc = @(
+        @{ op = 'add'; path = '/fields/System.State'; value = $State }
+    ) | ConvertTo-Json -Compress
+    $url = "$resolvedOrg/$resolvedProject/_apis/wit/workitems/${WorkItemId}?api-version=7.1"
+    Invoke-AdoApi -Method PATCH -Url $url -Body $patchDoc -ContentType 'application/json-patch+json' | Out-Null
+    log_info "Work item $WorkItemId state set to '$State'"
+}
+
+# Appends a tag to a work item without removing existing tags.
+# Usage: Add-WorkItemTag -WorkItemId <id> -Tag <tag>
+function Add-WorkItemTag {
+    param(
+        [string] $WorkItemId,
+        [string] $Tag
+    )
+    # Fetch current tags so we can append rather than overwrite.
+    $workItem    = Get-WorkItem -WorkItemId $WorkItemId
+    $currentTags = $workItem.fields.'System.Tags'
+    $newTags     = if ($currentTags) { "$currentTags; $Tag" } else { $Tag }
+
+    $patchDoc = @(
+        @{ op = 'add'; path = '/fields/System.Tags'; value = $newTags }
+    ) | ConvertTo-Json -Compress
+    $url = "$resolvedOrg/$resolvedProject/_apis/wit/workitems/${WorkItemId}?api-version=7.1"
+    Invoke-AdoApi -Method PATCH -Url $url -Body $patchDoc -ContentType 'application/json-patch+json' | Out-Null
+    log_info "Tag '$Tag' appended to work item $WorkItemId"
+}
+
+# Creates a pull request and links all PBI work items to it.
+# Returns the PR web URL as a string.
+# Usage: New-PullRequest -FeatureTitle <title> -FeatureBranch <branch> -Pbis <array>
+#   FeatureTitle  — Title string for the PR (becomes the PR title)
+#   FeatureBranch — Source branch name (e.g. agent/42-my-feature)
+#   Pbis          — Array of PBI work item objects with .id and .fields.'System.Title' present
+function New-PullRequest {
+    param(
+        [string]   $FeatureTitle,
+        [string]   $FeatureBranch,
+        [object[]] $Pbis
+    )
+
+    if (-not $resolvedRepoUrl) {
+        log_error "New-PullRequest: RepoUrl is not set — cannot determine repository for PR creation"
+        throw "RepoUrl is required for PR creation"
+    }
+
+    # Extract repository name from RepoUrl (last path segment after /_git/).
+    $repoId = ($resolvedRepoUrl -split '/_git/')[-1] -replace '[/?].*', ''
+
+    if (-not $repoId) {
+        log_error "New-PullRequest: unable to parse repository name from RepoUrl='$resolvedRepoUrl'"
+        throw "Could not parse repository name from RepoUrl"
+    }
+
+    # Build PR description listing all PBI IDs and titles.
+    $descLines   = $Pbis | ForEach-Object { "- #$($_.id): $($_.fields.'System.Title')" }
+    $description = $descLines -join "`n"
+
+    # Build workItemRefs array: [{ "id": "123" }, ...]
+    $workItemRefs = @($Pbis | ForEach-Object { @{ id = [string]$_.id } })
+
+    $body = @{
+        title         = $FeatureTitle
+        description   = $description
+        sourceRefName = "refs/heads/$FeatureBranch"
+        targetRefName = "refs/heads/$resolvedBaseBranch"
+        workItemRefs  = $workItemRefs
+    } | ConvertTo-Json -Depth 5 -Compress
+
+    $url      = "$resolvedOrg/$resolvedProject/_apis/git/repositories/$repoId/pullrequests?api-version=7.1"
+    $response = Invoke-AdoApi -Method POST -Url $url -Body $body
+
+    $prId     = $response.pullRequestId
+    $prWebUrl = "$resolvedOrg/$resolvedProject/_git/$repoId/pullrequest/$prId"
+    log_info "Pull request #${prId} created: $prWebUrl"
+    return $prWebUrl
+}
+
+# ── Dependency resolver ───────────────────────────────────────────────
+
+# Topologically sorts PBIs by their Dependency-Forward relations using
+# Kahn's algorithm.  PBIs with no predecessors appear first; the
+# relative order among independent PBIs is preserved from the input.
+#
+# Usage:  Sort-PbisByDependency -Pbis <array>
+#   Pbis — Array of PBI work item objects (with $expand=all so the
+#          .relations property is present).
+#
+# On success: returns an array of PBI objects in dependency order.
+# On cycle:   logs an error identifying the cycle and throws.
+# Empty input is handled gracefully (returns an empty array).
+function Sort-PbisByDependency {
+    param([object[]] $Pbis)
+
+    if ($null -eq $Pbis -or $Pbis.Count -eq 0) { return @() }
+
+    # Build set of IDs in scope for fast membership checks.
+    $idSet = @{}
+    foreach ($pbi in $Pbis) { $idSet[[string]$pbi.id] = $true }
+
+    # adj[$src]  = List<string> of successor IDs (PBIs that depend on $src)
+    # indeg[$id] = number of unprocessed predecessors for $id
+    $adj   = @{}
+    $indeg = @{}
+    foreach ($pbi in $Pbis) {
+        $id = [string]$pbi.id
+        $adj[$id]   = [System.Collections.Generic.List[string]]::new()
+        $indeg[$id] = 0
+    }
+
+    # Dependency-Forward on a PBI means "this PBI is a predecessor of the
+    # linked item" → edge: src → tgt (src must execute before tgt).
+    foreach ($pbi in $Pbis) {
+        $src  = [string]$pbi.id
+        $rels = if ($null -ne $pbi.relations) { @($pbi.relations) } else { @() }
+        foreach ($rel in $rels) {
+            if ($rel.rel -ne 'System.LinkTypes.Dependency-Forward') { continue }
+            $tgt = ($rel.url -split '/')[-1]
+            if (-not $idSet.ContainsKey($tgt)) { continue }
+            if ($adj[$src].Contains($tgt))     { continue }  # deduplicate
+            $adj[$src].Add($tgt)
+            $indeg[$tgt]++
+        }
+    }
+
+    # Kahn's algorithm — seed queue with zero-indegree nodes in original order.
+    $queue  = [System.Collections.Generic.Queue[string]]::new()
+    foreach ($pbi in $Pbis) {
+        if ($indeg[[string]$pbi.id] -eq 0) { $queue.Enqueue([string]$pbi.id) }
+    }
+
+    $sorted = [System.Collections.Generic.List[string]]::new()
+    while ($queue.Count -gt 0) {
+        $node = $queue.Dequeue()
+        $sorted.Add($node)
+        foreach ($succ in @($adj[$node])) {
+            $indeg[$succ]--
+            if ($indeg[$succ] -eq 0) { $queue.Enqueue($succ) }
+        }
+    }
+
+    # If not all nodes were processed a cycle exists.
+    if ($sorted.Count -ne $Pbis.Count) {
+        $cycleNodes = @(
+            $Pbis |
+            Where-Object { $indeg[[string]$_.id] -gt 0 } |
+            ForEach-Object { [string]$_.id }
+        )
+        $msg = "Sort-PbisByDependency: circular dependency detected among PBIs: $($cycleNodes -join ', ')"
+        log_error $msg
+        throw $msg
+    }
+
+    # Return PBI objects in sorted order.
+    $pbiMap = @{}
+    foreach ($pbi in $Pbis) { $pbiMap[[string]$pbi.id] = $pbi }
+    return @($sorted | ForEach-Object { $pbiMap[$_] })
+}
+
+# ── Git manager ────────────────────────────────────────────────────────
+
+# Resolves the default/base branch name.
+# Priority: resolvedBaseBranch config/CLI value > git symbolic-ref > error
+# Returns the branch name as a string. Throws on failure.
+function Get-DefaultBranch {
+    if ($resolvedBaseBranch) {
+        return $resolvedBaseBranch
+    }
+
+    $ref = git symbolic-ref refs/remotes/origin/HEAD 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $ref) {
+        $msg = "Get-DefaultBranch: cannot determine default branch — set baseBranch in config or -BaseBranch"
+        log_error $msg
+        throw $msg
+    }
+    # refs/remotes/origin/main → main
+    return ($ref -replace '^refs/remotes/origin/', '').Trim()
+}
+
+# Converts a Feature title to a URL-safe lowercase slug.
+# Replaces non-alphanumeric characters with hyphens, collapses runs,
+# and strips leading/trailing hyphens.
+# Usage: ConvertTo-Slug -Title <title>
+# Returns the slug string.
+function ConvertTo-Slug {
+    param([string]$Title)
+    $slug = $Title.ToLowerInvariant()
+    $slug = $slug -replace '[^a-z0-9]', '-'
+    $slug = $slug -replace '-+', '-'
+    $slug = $slug.Trim('-')
+    return $slug
+}
+
+# Creates a feature branch named agent/<FeatureId>-<slug> from the base branch
+# and pushes it to origin.
+# Usage: New-FeatureBranch -FeatureId <id> -FeatureTitle <title>
+# Returns the branch name as a string. Throws on failure.
+function New-FeatureBranch {
+    param(
+        [string] $FeatureId,
+        [string] $FeatureTitle
+    )
+
+    $baseBranch = Get-DefaultBranch
+    $slug       = ConvertTo-Slug -Title $FeatureTitle
+    $branchName = "agent/$FeatureId-$slug"
+
+    log_info "Creating branch '$branchName' from '$baseBranch'"
+
+    git fetch origin $baseBranch 2>&1 | ForEach-Object { log_info "git: $_" }
+    if ($LASTEXITCODE -ne 0) {
+        $msg = "New-FeatureBranch: failed to fetch '$baseBranch' from origin"
+        log_error $msg
+        throw $msg
+    }
+
+    # Check if branch already exists locally.
+    git show-ref --verify --quiet "refs/heads/$branchName" 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        log_info "Branch '$branchName' already exists locally — checking out"
+        git checkout $branchName 2>&1 | ForEach-Object { log_info "git: $_" }
+    } else {
+        git checkout -b $branchName "origin/$baseBranch" 2>&1 | ForEach-Object { log_info "git: $_" }
+    }
+    if ($LASTEXITCODE -ne 0) {
+        $msg = "New-FeatureBranch: failed to create or checkout branch '$branchName'"
+        log_error $msg
+        throw $msg
+    }
+
+    git push -u origin $branchName 2>&1 | ForEach-Object { log_info "git: $_" }
+    if ($LASTEXITCODE -ne 0) {
+        $msg = "New-FeatureBranch: failed to push '$branchName' to origin"
+        log_error $msg
+        throw $msg
+    }
+
+    log_info "Branch '$branchName' created and pushed to origin"
+    return $branchName
+}
+
+# Verifies that the working tree is clean (no uncommitted changes) and that
+# all commits on the feature branch have been pushed to origin.
+# Usage: Test-CleanAndPushed -FeatureBranch <branch>
+# Returns $true if both conditions hold, $false otherwise.
+function Test-CleanAndPushed {
+    param([string] $FeatureBranch)
+
+    $statusOutput = git status --porcelain 2>&1
+    if ($statusOutput) {
+        log_error "Test-CleanAndPushed: working tree is not clean — uncommitted changes detected"
+        log_error ($statusOutput -join "`n")
+        return $false
+    }
+
+    # Fetch to make sure remote tracking ref is current.
+    git fetch origin $FeatureBranch 2>$null | Out-Null
+
+    $unpushed = git log "origin/${FeatureBranch}..HEAD" --oneline 2>&1
+    if ($unpushed) {
+        log_error "Test-CleanAndPushed: there are unpushed commits on '$FeatureBranch':"
+        log_error ($unpushed -join "`n")
+        return $false
+    }
+
+    return $true
+}
+
+# ── Agent dispatcher ───────────────────────────────────────────────────
+
+# Assembles the prompt that will be sent to the AI agent.
+# The prompt includes PBI title, description, and acceptance criteria,
+# plus instructions to read feature context and signal completion.
+# Usage: Build-Prompt -PbiTitle <title> -PbiDescription <desc> -AcceptanceCriteria <ac>
+# Returns the assembled prompt string.
+function Build-Prompt {
+    param(
+        [string] $PbiTitle,
+        [string] $PbiDescription,
+        [string] $AcceptanceCriteria
+    )
+
+    return @"
+You are an autonomous software development agent implementing a Product Backlog Item (PBI).
+
+## PBI Details
+
+**Title:** $PbiTitle
+
+**Description:**
+$PbiDescription
+
+**Acceptance Criteria:**
+$AcceptanceCriteria
+
+## Feature Context
+
+Read the file ```.agent-context/feature.md``` in your working directory for additional context about the parent Feature this PBI belongs to.
+
+## Instructions
+
+1. Implement the PBI described above, satisfying all acceptance criteria.
+2. Write, edit, and test code as needed using the tools available to you.
+3. Commit your changes with a clear commit message referencing the work done.
+4. Push the commit to the remote origin. Do NOT create a pull request.
+5. When you have finished implementing and pushing all changes, output the exact string ``AGENT_COMPLETE`` on a line by itself to signal completion.
+"@
+}
+
+# Dispatches the configured AI provider with the given prompt and captures output.
+# Returns a hashtable with:
+#   ExitCode   — exit code from the agent process
+#   Completed  — $true if AGENT_COMPLETE was detected in output, else $false
+#   Output     — the captured agent output string
+# Throws if the provider value is not recognised.
+# Usage: Invoke-Agent -Prompt <string>
+function Invoke-Agent {
+    param([string] $Prompt)
+
+    $output   = ''
+    $exitCode = 0
+
+    switch ($resolvedProvider) {
+        'claude-code' {
+            $modelArgs = if ($resolvedModel) { @('--model', $resolvedModel) } else { @() }
+            try {
+                $output = & claude -p $Prompt `
+                    --output-format json `
+                    @modelArgs `
+                    --allowedTools 'Read,Write,Edit,Bash' `
+                    --max-turns $resolvedMaxIterations 2>&1 | Out-String
+            } catch {
+                $output   = $_.Exception.Message
+                $exitCode = 1
+            }
+            $exitCode = $LASTEXITCODE
+        }
+        'cursor-cli' {
+            try {
+                $output = & agent -p $Prompt --force --output-format json 2>&1 | Out-String
+            } catch {
+                $output   = $_.Exception.Message
+                $exitCode = 1
+            }
+            $exitCode = $LASTEXITCODE
+        }
+        default {
+            $msg = "Invoke-Agent: unknown provider '$resolvedProvider'. Must be 'claude-code' or 'cursor-cli'."
+            log_error $msg
+            throw $msg
+        }
+    }
+
+    $completed = $output -match 'AGENT_COMPLETE'
+
+    if ($exitCode -ne 0) {
+        log_error "Invoke-Agent: agent exited with non-zero exit code $exitCode"
+    }
+
+    return @{
+        ExitCode  = $exitCode
+        Completed = $completed
+        Output    = $output
+    }
+}
+
+# ── Inner Ralph loop ───────────────────────────────────────────────────
+
+# Inner loop that processes a single PBI through repeated agent invocations
+# until the work is verifiably complete or the max iteration limit is hit.
+#
+# Sets PBI state to "In Progress" before the first invocation. Each iteration
+# invokes the agent with a fresh context (no session resumption). The stop
+# condition requires BOTH an AGENT_COMPLETE signal AND a clean, fully-pushed
+# working tree. On success the PBI is tagged "agent-done"; on exhaustion or
+# agent error it is tagged "agent-failed".
+#
+# Usage: Invoke-ProcessPbi -PbiId <id> -PbiTitle <title> -PbiDescription <desc> -AcceptanceCriteria <ac> -FeatureBranch <branch> -FeatureId <id>
+# Returns $true on success, $false on failure.
+function Invoke-ProcessPbi {
+    param(
+        [string] $PbiId,
+        [string] $PbiTitle,
+        [string] $PbiDescription,
+        [string] $AcceptanceCriteria,
+        [string] $FeatureBranch,
+        [string] $FeatureId
+    )
+
+    log_info "Starting inner loop for PBI ${PbiId}: $PbiTitle"
+
+    # Set PBI state to "In Progress" before first agent invocation.
+    try {
+        Update-WorkItemState -WorkItemId $PbiId -State 'In Progress'
+    } catch {
+        log_error "Invoke-ProcessPbi: failed to set PBI $PbiId to 'In Progress' — aborting"
+        return $false
+    }
+
+    $prompt = Build-Prompt -PbiTitle $PbiTitle -PbiDescription $PbiDescription -AcceptanceCriteria $AcceptanceCriteria
+
+    for ($iteration = 1; $iteration -le $resolvedMaxIterations; $iteration++) {
+        log_info "Iteration ${iteration}/$resolvedMaxIterations for PBI $PbiId"
+
+        $result = Invoke-Agent -Prompt $prompt
+
+        # Capture agent output to the context log for this feature.
+        Capture-AgentLog -FeatureId $FeatureId -Output $result.Output
+
+        # Stop condition: AGENT_COMPLETE signal AND clean+pushed working tree.
+        if ($result.Completed -and (Test-CleanAndPushed -FeatureBranch $FeatureBranch)) {
+            log_info "PBI $PbiId completed successfully after $iteration iteration(s)"
+            try { Add-WorkItemTag -WorkItemId $PbiId -Tag 'agent-done' } catch { log_warn "Invoke-ProcessPbi: failed to tag PBI $PbiId as agent-done" }
+            return $true
+        }
+
+        # If the agent process itself errored, stop retrying immediately.
+        if ($result.ExitCode -ne 0) {
+            log_error "Invoke-ProcessPbi: agent exited with code $($result.ExitCode) on iteration $iteration — stopping"
+            break
+        }
+    }
+
+    log_error "Invoke-ProcessPbi: PBI $PbiId did not complete within $resolvedMaxIterations iteration(s)"
+    try { Add-WorkItemTag -WorkItemId $PbiId -Tag 'agent-failed' } catch { log_warn "Invoke-ProcessPbi: failed to tag PBI $PbiId as agent-failed" }
+    return $false
+}
+
+try {
+    Acquire-Lock
+    Ensure-Gitignore
+
+    # ── Orchestrator ──────────────────────────────────────────────────────
+
+    log_info "agent-loop started"
+
+    # Step 3/4: Determine the Feature to process
+    if ($resolvedFeatureId) {
+        # One-shot mode: -FeatureId was supplied
+        log_info "One-shot mode: processing Feature $resolvedFeatureId"
+        $featureJson = Get-WorkItem -WorkItemId $resolvedFeatureId
+        $featureId   = [string]$resolvedFeatureId
+    } else {
+        # Scheduled mode: pick the first eligible Feature
+        log_info "Scheduled mode: querying for eligible Features"
+        $eligibleIds = @(Get-EligibleFeatures)
+        if ($eligibleIds.Count -eq 0) {
+            log_info "No eligible Features found — nothing to do"
+            exit 0
+        }
+        $featureId   = [string]$eligibleIds[0]
+        log_info "Selected Feature $featureId for processing"
+        $featureJson = Get-WorkItem -WorkItemId $featureId
+    }
+
+    $featureTitle       = $featureJson.fields.'System.Title'
+    $featureDescription = $featureJson.fields.'System.Description'
+
+    log_info "Processing Feature ${featureId}: $featureTitle"
+
+    # Step 5: Fetch all child PBIs
+    log_info "Fetching child PBIs for Feature $featureId"
+    $pbis = @(Get-ChildPbis -FeatureId $featureId)
+
+    if ($pbis.Count -eq 0) {
+        log_info "Feature $featureId has no child PBIs — nothing to do"
+        exit 0
+    }
+    log_info "Found $($pbis.Count) PBI(s) for Feature $featureId"
+
+    # Step 6: Topologically sort PBIs by dependency
+    log_info "Sorting PBIs by dependency order"
+    $sortedPbis = @(Sort-PbisByDependency -Pbis $pbis)
+
+    # Step 7: Create feature branch
+    log_info "Creating feature branch for Feature $featureId"
+    $featureBranch = New-FeatureBranch -FeatureId $featureId -FeatureTitle $featureTitle
+
+    # Step 8: Write Feature PRD to .agent-context/feature.md
+    $featureContext = "# Feature: $featureTitle`n`n## Description`n$featureDescription"
+    Write-FeatureContext -FeatureId $featureId -Content $featureContext
+
+    # Step 9/10: Process each PBI serially; stop on first failure
+    $featureSuccess = $true
+    foreach ($pbi in $sortedPbis) {
+        $pbiId          = [string]$pbi.id
+        $pbiTitle       = $pbi.fields.'System.Title'
+        $pbiDescription = $pbi.fields.'System.Description'
+        $pbiAc          = $pbi.fields.'Microsoft.VSTS.Common.AcceptanceCriteria'
+
+        log_info "Starting PBI ${pbiId}: $pbiTitle"
+
+        $ok = Invoke-ProcessPbi `
+            -PbiId              $pbiId `
+            -PbiTitle           ($pbiTitle       ?? '') `
+            -PbiDescription     ($pbiDescription ?? '') `
+            -AcceptanceCriteria ($pbiAc          ?? '') `
+            -FeatureBranch      $featureBranch `
+            -FeatureId          $featureId
+
+        if (-not $ok) {
+            log_error "PBI $pbiId failed — skipping remaining PBIs for Feature $featureId"
+            $featureSuccess = $false
+            break
+        }
+
+        log_info "PBI $pbiId completed"
+    }
+
+    # Step 11: Create PR only when all PBIs are tagged agent-done
+    if ($featureSuccess) {
+        log_info "All PBIs completed — creating pull request for Feature $featureId"
+        $prUrl = New-PullRequest -FeatureTitle $featureTitle -FeatureBranch $featureBranch -Pbis $sortedPbis
+        log_info "Feature $featureId complete — PR: $prUrl"
+        exit 0
+    } else {
+        log_error "Feature $featureId processing failed — one or more PBIs did not complete"
+        exit 1
+    }
+} finally {
+    Release-Lock
+    Invoke-Cleanup
+}

--- a/agent-loop/agent-loop.sh
+++ b/agent-loop/agent-loop.sh
@@ -1,0 +1,948 @@
+#!/bin/bash
+set -e
+
+# ── agent-loop.sh ─────────────────────────────────────────────────────
+# Autonomous ADO feature implementation loop.
+# Reads config from .agent-loop.json in the working directory and/or
+# CLI parameters (CLI wins). Validates all required values before running.
+
+# ── Config defaults ───────────────────────────────────────────────────
+CONFIG_ORG=""
+CONFIG_PROJECT=""
+CONFIG_AREA_PATH=""
+CONFIG_TEAM=""
+CONFIG_PROCESS=""
+CONFIG_REPO_URL=""
+CONFIG_BASE_BRANCH=""
+CONFIG_MAX_ITERATIONS=""
+CONFIG_PROVIDER=""
+CONFIG_MODEL=""
+CONFIG_WORKING_DIRECTORY=""
+CONFIG_FEATURE_ID=""
+
+# ── CLI parameter parsing ─────────────────────────────────────────────
+CLI_ORG=""
+CLI_PROJECT=""
+CLI_AREA_PATH=""
+CLI_TEAM=""
+CLI_PROCESS=""
+CLI_REPO_URL=""
+CLI_BASE_BRANCH=""
+CLI_MAX_ITERATIONS=""
+CLI_PROVIDER=""
+CLI_MODEL=""
+CLI_WORKING_DIRECTORY=""
+CLI_FEATURE_ID=""
+
+# ── Logging ───────────────────────────────────────────────────────────
+log_info() {
+  echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] [INFO] $*"
+}
+
+log_warn() {
+  echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] [WARN] $*" >&2
+}
+
+log_error() {
+  echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] [ERROR] $*" >&2
+}
+
+print_usage() {
+  cat <<EOF
+Usage: agent-loop.sh [OPTIONS]
+
+Options:
+  --org <url>               Azure DevOps org URL (e.g. https://dev.azure.com/contoso)
+  --project <name>          Azure DevOps project name
+  --area-path <path>        Work item area path (e.g. "MyProject\\Team A")
+  --team <name>             Azure DevOps team name
+  --process <template>      Process template: Scrum, Agile, or CMMI
+  --repo-url <url>          Git repository URL
+  --base-branch <branch>    Base branch to branch from (default: main)
+  --max-iterations <n>      Maximum loop iterations (default: 50)
+  --provider <name>         AI provider: claude-code or cursor-cli
+  --model <id>              Model ID to use (e.g. claude-opus-4-6)
+  --working-directory <dir> Working directory containing the repo
+  --feature-id <id>         ADO Feature ID to process (optional; processes all if omitted)
+
+Environment variables:
+  AZURE_DEVOPS_PAT          Required. Azure DevOps Personal Access Token.
+  ANTHROPIC_API_KEY         Required when --provider is anthropic.
+  CURSOR_API_KEY            Required when --provider is cursor.
+
+Config file:
+  .agent-loop.json          Optional JSON config in the working directory.
+                            CLI parameters override config file values.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --org)              CLI_ORG="$2";               shift 2 ;;
+    --project)          CLI_PROJECT="$2";           shift 2 ;;
+    --area-path)        CLI_AREA_PATH="$2";         shift 2 ;;
+    --team)             CLI_TEAM="$2";              shift 2 ;;
+    --process)          CLI_PROCESS="$2";           shift 2 ;;
+    --repo-url)         CLI_REPO_URL="$2";          shift 2 ;;
+    --base-branch)      CLI_BASE_BRANCH="$2";       shift 2 ;;
+    --max-iterations)   CLI_MAX_ITERATIONS="$2";    shift 2 ;;
+    --provider)         CLI_PROVIDER="$2";          shift 2 ;;
+    --model)            CLI_MODEL="$2";             shift 2 ;;
+    --working-directory) CLI_WORKING_DIRECTORY="$2"; shift 2 ;;
+    --feature-id)       CLI_FEATURE_ID="$2";        shift 2 ;;
+    --help|-h)          print_usage; exit 0 ;;
+    *)
+      echo "Error: Unknown option: $1" >&2
+      print_usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Load config file ──────────────────────────────────────────────────
+# Resolve working directory: CLI > env > current directory
+WORKING_DIR="${CLI_WORKING_DIRECTORY:-${AGENT_LOOP_WORKING_DIRECTORY:-$(pwd)}}"
+CONFIG_FILE="$WORKING_DIR/.agent-loop.json"
+
+if [ -f "$CONFIG_FILE" ]; then
+  if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required to parse .agent-loop.json. Install with: brew install jq / sudo apt install jq" >&2
+    exit 1
+  fi
+
+  CONFIG_ORG=$(jq -r '.org // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_PROJECT=$(jq -r '.project // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_AREA_PATH=$(jq -r '.areaPath // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_TEAM=$(jq -r '.team // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_PROCESS=$(jq -r '.process // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_REPO_URL=$(jq -r '.repoUrl // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_BASE_BRANCH=$(jq -r '.baseBranch // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_MAX_ITERATIONS=$(jq -r '.maxIterations // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_PROVIDER=$(jq -r '.provider // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_MODEL=$(jq -r '.model // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_WORKING_DIRECTORY=$(jq -r '.workingDirectory // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_FEATURE_ID=$(jq -r '.featureId // empty' "$CONFIG_FILE" 2>/dev/null || true)
+fi
+
+# ── Merge: CLI wins over config file ─────────────────────────────────
+ORG="${CLI_ORG:-$CONFIG_ORG}"
+PROJECT="${CLI_PROJECT:-$CONFIG_PROJECT}"
+AREA_PATH="${CLI_AREA_PATH:-$CONFIG_AREA_PATH}"
+TEAM="${CLI_TEAM:-$CONFIG_TEAM}"
+PROCESS="${CLI_PROCESS:-$CONFIG_PROCESS}"
+REPO_URL="${CLI_REPO_URL:-$CONFIG_REPO_URL}"
+BASE_BRANCH="${CLI_BASE_BRANCH:-${CONFIG_BASE_BRANCH:-main}}"
+MAX_ITERATIONS="${CLI_MAX_ITERATIONS:-${CONFIG_MAX_ITERATIONS:-50}}"
+PROVIDER="${CLI_PROVIDER:-$CONFIG_PROVIDER}"
+MODEL="${CLI_MODEL:-$CONFIG_MODEL}"
+FEATURE_ID="${CLI_FEATURE_ID:-$CONFIG_FEATURE_ID}"
+
+# ── Validate required values ──────────────────────────────────────────
+ERRORS=()
+
+[ -z "$ORG" ]      && ERRORS+=("Missing required value: --org (Azure DevOps org URL)")
+[ -z "$PROJECT" ]  && ERRORS+=("Missing required value: --project (Azure DevOps project name)")
+[ -z "$PROVIDER" ] && ERRORS+=("Missing required value: --provider (claude-code or cursor-cli)")
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo "Error: Configuration is incomplete:" >&2
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err" >&2
+  done
+  echo "" >&2
+  echo "Provide values via CLI parameters or .agent-loop.json in the working directory." >&2
+  echo "See .agent-loop.example.json for the full schema." >&2
+  exit 1
+fi
+
+# ── Validate provider value ───────────────────────────────────────────
+if [[ "$PROVIDER" != "claude-code" && "$PROVIDER" != "cursor-cli" ]]; then
+  echo "Error: Invalid provider '$PROVIDER'. Must be 'claude-code' or 'cursor-cli'." >&2
+  exit 1
+fi
+
+# ── Validate environment variables ───────────────────────────────────
+ENV_ERRORS=()
+
+if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
+  ENV_ERRORS+=("Missing required environment variable: AZURE_DEVOPS_PAT")
+fi
+
+if [ "$PROVIDER" = "claude-code" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  ENV_ERRORS+=("Missing required environment variable: ANTHROPIC_API_KEY (required for provider=claude-code)")
+fi
+
+if [ "$PROVIDER" = "cursor-cli" ] && [ -z "${CURSOR_API_KEY:-}" ]; then
+  ENV_ERRORS+=("Missing required environment variable: CURSOR_API_KEY (required for provider=cursor-cli)")
+fi
+
+if [ ${#ENV_ERRORS[@]} -gt 0 ]; then
+  echo "Error: Required environment variables are not set:" >&2
+  for err in "${ENV_ERRORS[@]}"; do
+    echo "  - $err" >&2
+  done
+  exit 1
+fi
+
+# ── Export resolved config for use by the rest of the script ─────────
+export AGENT_LOOP_ORG="$ORG"
+export AGENT_LOOP_PROJECT="$PROJECT"
+export AGENT_LOOP_AREA_PATH="$AREA_PATH"
+export AGENT_LOOP_TEAM="$TEAM"
+export AGENT_LOOP_PROCESS="$PROCESS"
+export AGENT_LOOP_REPO_URL="$REPO_URL"
+export AGENT_LOOP_BASE_BRANCH="$BASE_BRANCH"
+export AGENT_LOOP_MAX_ITERATIONS="$MAX_ITERATIONS"
+export AGENT_LOOP_PROVIDER="$PROVIDER"
+export AGENT_LOOP_MODEL="$MODEL"
+export AGENT_LOOP_WORKING_DIRECTORY="$WORKING_DIR"
+export AGENT_LOOP_FEATURE_ID="$FEATURE_ID"
+
+echo "══════════════════════════════════════════════════════"
+echo "  agent-loop"
+echo "  Org:             $ORG"
+echo "  Project:         $PROJECT"
+echo "  Provider:        $PROVIDER${MODEL:+ ($MODEL)}"
+echo "  Base branch:     $BASE_BRANCH"
+echo "  Max iterations:  $MAX_ITERATIONS"
+[ -n "$FEATURE_ID" ] && echo "  Feature ID:      $FEATURE_ID"
+[ -n "$AREA_PATH" ]  && echo "  Area path:       $AREA_PATH"
+[ -n "$TEAM" ]       && echo "  Team:            $TEAM"
+[ -n "$REPO_URL" ]   && echo "  Repo URL:        $REPO_URL"
+echo "══════════════════════════════════════════════════════"
+
+# ── Lock manager ──────────────────────────────────────────────────────
+LOCK_FILE="$WORKING_DIR/.agent-loop.lock"
+
+acquire_lock() {
+  if ! ( set -o noclobber; echo "$$" > "$LOCK_FILE" ) 2>/dev/null; then
+    log_warn "Another instance is already running (lock file exists: $LOCK_FILE). Exiting."
+    exit 0
+  fi
+  log_info "Lock acquired: $LOCK_FILE"
+}
+
+release_lock() {
+  if [ -f "$LOCK_FILE" ]; then
+    rm -f "$LOCK_FILE"
+    log_info "Lock released: $LOCK_FILE"
+  fi
+}
+
+# ── Context manager ───────────────────────────────────────────────────
+AGENT_CONTEXT_DIR="$WORKING_DIR/.agent-context"
+
+ensure_gitignore() {
+  local gitignore="$WORKING_DIR/.gitignore"
+  if [ ! -f "$gitignore" ] || ! grep -qxF '.agent-context/' "$gitignore"; then
+    echo '.agent-context/' >> "$gitignore"
+    log_info ".agent-context/ added to .gitignore"
+  fi
+}
+
+write_feature_context() {
+  local feature_id="$1"
+  local content="$2"
+  mkdir -p "$AGENT_CONTEXT_DIR"
+  printf '%s' "$content" > "$AGENT_CONTEXT_DIR/feature.md"
+  log_info "Feature context written to .agent-context/feature.md (feature $feature_id)"
+}
+
+capture_agent_log() {
+  local feature_id="$1"
+  local output="$2"
+  mkdir -p "$AGENT_CONTEXT_DIR/logs"
+  printf '%s\n' "$output" >> "$AGENT_CONTEXT_DIR/logs/feature-${feature_id}.log"
+}
+
+cleanup() {
+  if [ -d "$AGENT_CONTEXT_DIR" ]; then
+    rm -rf "$AGENT_CONTEXT_DIR"
+    log_info "Cleaned up .agent-context/"
+  fi
+}
+
+# ── ADO Client ────────────────────────────────────────────────────────
+
+# Returns "Basic <base64(:PAT)>" for use in Authorization headers.
+_ado_auth_header() {
+  printf 'Basic %s' "$(printf ':%s' "$AZURE_DEVOPS_PAT" | base64 | tr -d '\n')"
+}
+
+# Makes an ADO REST API call.
+# Prints the response body on success (HTTP 2xx).
+# Logs an error and returns 1 on failure.
+# Usage: _ado_call <METHOD> <URL> [JSON_BODY] [CONTENT_TYPE]
+_ado_call() {
+  local method="$1"
+  local url="$2"
+  local body="${3:-}"
+  local content_type="${4:-application/json}"
+  local auth
+  auth=$(_ado_auth_header)
+
+  local tmp_body
+  tmp_body=$(mktemp)
+
+  local http_code
+  if [ -n "$body" ]; then
+    http_code=$(curl -s -o "$tmp_body" -w '%{http_code}' \
+      -X "$method" \
+      -H "Authorization: $auth" \
+      -H "Content-Type: $content_type" \
+      -d "$body" \
+      "$url")
+  else
+    http_code=$(curl -s -o "$tmp_body" -w '%{http_code}' \
+      -X "$method" \
+      -H "Authorization: $auth" \
+      "$url")
+  fi
+
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    log_error "ADO API error: HTTP $http_code — $method $url"
+    log_error "Response: $(cat "$tmp_body")"
+    rm -f "$tmp_body"
+    return 1
+  fi
+
+  cat "$tmp_body"
+  rm -f "$tmp_body"
+}
+
+# Queries ADO for Features that have at least one child PBI tagged
+# "ready-for-agent" in "New" state, scoped to the configured areaPath.
+# Prints one Feature ID per line.
+query_eligible_features() {
+  local wiql="SELECT [System.Id] FROM WorkItemLinks WHERE [Source].[System.WorkItemType] = 'Feature'"
+  if [ -n "$AREA_PATH" ]; then
+    wiql+=" AND [Source].[System.AreaPath] UNDER '$AREA_PATH'"
+  fi
+  wiql+=" AND [Target].[System.Tags] CONTAINS 'ready-for-agent' AND [Target].[System.State] = 'New' AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' MODE (MustContain)"
+
+  local payload
+  payload=$(jq -n --arg q "$wiql" '{"query": $q}')
+
+  local url="${ORG}/${PROJECT}/_apis/wit/wiql?api-version=7.1"
+  local response
+  response=$(_ado_call POST "$url" "$payload") || return 1
+
+  # Extract unique source Feature IDs (source is null for the root row; skip it).
+  echo "$response" | jq -r '[.workItemRelations[].source | select(. != null) | .id] | unique | .[]'
+}
+
+# Fetches all child PBIs of a Feature, expanding all fields and relations
+# (including Dependency-Forward links needed by the dependency resolver).
+# Prints the raw JSON "value" array from the batch work-items response.
+# Usage: get_child_pbis <feature_id>
+get_child_pbis() {
+  local feature_id="$1"
+
+  # Fetch the Feature to get its relations.
+  local feature_url="${ORG}/${PROJECT}/_apis/wit/workitems/${feature_id}?\$expand=relations&api-version=7.1"
+  local feature_json
+  feature_json=$(_ado_call GET "$feature_url") || return 1
+
+  # Extract IDs of direct children (Hierarchy-Forward from Feature to PBI).
+  local child_ids
+  child_ids=$(echo "$feature_json" | jq -r '
+    (.relations // [])
+    | map(select(.rel == "System.LinkTypes.Hierarchy-Forward"))
+    | map(.url | split("/") | last)
+    | .[]
+  ')
+
+  if [ -z "$child_ids" ]; then
+    log_info "No child PBIs found for Feature $feature_id"
+    echo "[]"
+    return 0
+  fi
+
+  local ids_param
+  ids_param=$(echo "$child_ids" | tr '\n' ',' | sed 's/,$//')
+
+  # Fetch all child PBIs with full expansion (fields + relations).
+  local pbis_url="${ORG}/${PROJECT}/_apis/wit/workitems?ids=${ids_param}&\$expand=all&api-version=7.1"
+  local pbis_json
+  pbis_json=$(_ado_call GET "$pbis_url") || return 1
+
+  echo "$pbis_json" | jq '.value'
+}
+
+# Fetches a single work item by ID with all fields and relations expanded.
+# Prints the raw work item JSON object.
+# Usage: get_work_item <work_item_id>
+get_work_item() {
+  local work_item_id="$1"
+  local url="${ORG}/${PROJECT}/_apis/wit/workitems/${work_item_id}?\$expand=all&api-version=7.1"
+  _ado_call GET "$url"
+}
+
+# Transitions a work item to the given state.
+# The caller is responsible for passing the correct state name for the process
+# template (e.g. "Active" for Agile, "In Progress" for Scrum).
+# Usage: update_work_item_state <work_item_id> <state>
+update_work_item_state() {
+  local work_item_id="$1"
+  local state="$2"
+
+  local payload
+  payload=$(jq -n --arg s "$state" '[{"op":"add","path":"/fields/System.State","value":$s}]')
+
+  local url="${ORG}/${PROJECT}/_apis/wit/workitems/${work_item_id}?api-version=7.1"
+  _ado_call PATCH "$url" "$payload" "application/json-patch+json" || return 1
+  log_info "Work item $work_item_id state set to '$state'"
+}
+
+# Appends a tag to a work item without removing existing tags.
+# Usage: add_work_item_tag <work_item_id> <tag>
+add_work_item_tag() {
+  local work_item_id="$1"
+  local tag="$2"
+
+  # Fetch current tags so we can append rather than overwrite.
+  local work_item
+  work_item=$(get_work_item "$work_item_id") || return 1
+
+  local current_tags
+  current_tags=$(echo "$work_item" | jq -r '.fields["System.Tags"] // ""')
+
+  local new_tags
+  if [ -z "$current_tags" ]; then
+    new_tags="$tag"
+  else
+    new_tags="${current_tags}; ${tag}"
+  fi
+
+  local payload
+  payload=$(jq -n --arg t "$new_tags" '[{"op":"add","path":"/fields/System.Tags","value":$t}]')
+
+  local url="${ORG}/${PROJECT}/_apis/wit/workitems/${work_item_id}?api-version=7.1"
+  _ado_call PATCH "$url" "$payload" "application/json-patch+json" || return 1
+  log_info "Tag '$tag' appended to work item $work_item_id"
+}
+
+# Creates a pull request and links all PBI work items to it.
+# Usage: create_pull_request <feature_title> <feature_branch> <pbis_json>
+#   feature_title  — Title string for the PR (becomes the PR title)
+#   feature_branch — Source branch name (e.g. agent/42-my-feature)
+#   pbis_json      — JSON array of PBI work item objects with .id and
+#                    .fields["System.Title"] present
+# Prints the PR web URL on success. Returns 1 on failure.
+create_pull_request() {
+  local feature_title="$1"
+  local feature_branch="$2"
+  local pbis_json="$3"
+
+  if [ -z "$REPO_URL" ]; then
+    log_error "create_pull_request: REPO_URL is not set — cannot determine repository for PR creation"
+    return 1
+  fi
+
+  # Extract repository name from REPO_URL (last path segment after /_git/).
+  local repo_id
+  repo_id=$(printf '%s' "$REPO_URL" | sed 's|.*/_git/||' | sed 's|[/?].*||')
+
+  if [ -z "$repo_id" ]; then
+    log_error "create_pull_request: unable to parse repository name from REPO_URL='$REPO_URL'"
+    return 1
+  fi
+
+  # Build PR description listing all PBI IDs and titles.
+  local description
+  description=$(printf '%s' "$pbis_json" | jq -r '
+    map("- #\(.id): \(.fields["System.Title"])")
+    | join("\n")
+  ')
+
+  # Build workItemRefs array: [{ "id": "123" }, ...]
+  local work_item_refs
+  work_item_refs=$(printf '%s' "$pbis_json" | jq '[.[] | {"id": (.id | tostring)}]')
+
+  local payload
+  payload=$(jq -n \
+    --arg title  "$feature_title" \
+    --arg src    "refs/heads/$feature_branch" \
+    --arg tgt    "refs/heads/$BASE_BRANCH" \
+    --arg desc   "$description" \
+    --argjson wir "$work_item_refs" \
+    '{
+      "title":         $title,
+      "description":   $desc,
+      "sourceRefName": $src,
+      "targetRefName": $tgt,
+      "workItemRefs":  $wir
+    }')
+
+  local url="${ORG}/${PROJECT}/_apis/git/repositories/${repo_id}/pullrequests?api-version=7.1"
+  local response
+  response=$(_ado_call POST "$url" "$payload") || {
+    log_error "create_pull_request: failed to create PR for branch '$feature_branch'"
+    return 1
+  }
+
+  local pr_id
+  pr_id=$(printf '%s' "$response" | jq -r '.pullRequestId // empty')
+
+  if [ -z "$pr_id" ]; then
+    log_error "create_pull_request: PR created but could not parse pullRequestId from response"
+    return 1
+  fi
+
+  local pr_web_url="${ORG}/${PROJECT}/_git/${repo_id}/pullrequest/${pr_id}"
+  log_info "Pull request #${pr_id} created: $pr_web_url"
+  printf '%s\n' "$pr_web_url"
+}
+
+# ── Dependency resolver ───────────────────────────────────────────────
+
+# Topologically sorts PBIs by their Dependency-Forward relations using
+# Kahn's algorithm.  PBIs with no predecessors appear first; the
+# relative order among independent PBIs is preserved from the input.
+#
+# Usage:  sort_pbis_by_dependency <pbis_json>
+#   pbis_json — JSON array of PBI work item objects (with $expand=all so
+#               the .relations field is present).
+#
+# On success: prints a JSON array of PBI objects in dependency order.
+# On cycle:   logs an error identifying the cycle and returns 1.
+# Empty input is handled gracefully (prints "[]").
+sort_pbis_by_dependency() {
+  local pbis_json="$1"
+
+  # The entire algorithm runs inside jq (already required by the script).
+  # Dependency-Forward on a PBI means "this PBI is a predecessor of the
+  # linked item" → edge: src → tgt (src must execute before tgt).
+  local jq_prog='
+. as $pbis |
+(map(.id | tostring) | unique) as $allIds |
+if ($allIds | length) == 0 then {"ok": true, "result": []}
+else
+  ($pbis | map({key: (.id | tostring), value: .}) | from_entries) as $pbiMap |
+  ($allIds | map({key: ., value: 0}) | from_entries) as $initIndeg |
+  (reduce $pbis[] as $pbi (
+    {adj: {}, indeg: $initIndeg};
+    ($pbi.id | tostring) as $src |
+    .adj[$src] //= [] |
+    reduce (($pbi.relations // [])[] | select(.rel == "System.LinkTypes.Dependency-Forward")) as $rel (
+      .;
+      ($rel.url | split("/") | last) as $tgt |
+      if ($initIndeg | has($tgt)) and ((.adj[$src] | index($tgt)) == null) then
+        .adj[$src] += [$tgt] |
+        .indeg[$tgt] += 1
+      else . end
+    )
+  )) as $g |
+  def kahn(adj; indeg; queue; sorted):
+    if (queue | length) == 0 then {indeg: indeg, sorted: sorted}
+    else
+      queue[0] as $node |
+      queue[1:] as $rest |
+      reduce (adj[$node] // [])[] as $succ (
+        {indeg: indeg, queue: $rest};
+        .indeg[$succ] -= 1 |
+        if .indeg[$succ] == 0 then .queue += [$succ] else . end
+      ) as $s |
+      kahn(adj; $s.indeg; $s.queue; sorted + [$node])
+    end;
+  ($allIds | map(select($g.indeg[.] == 0))) as $q0 |
+  kahn($g.adj; $g.indeg; $q0; []) as $r |
+  if ($r.sorted | length) != ($allIds | length) then
+    ($r.indeg | to_entries | map(select(.value > 0)) | map(.key)) as $cycle |
+    {"ok": false, "error": "Circular dependency detected among PBIs: \($cycle | join(", "))"}
+  else
+    {"ok": true, "result": ($r.sorted | map($pbiMap[.]))}
+  end
+end
+'
+
+  local result
+  result=$(echo "$pbis_json" | jq "$jq_prog") || {
+    log_error "sort_pbis_by_dependency: jq failed to process PBI list"
+    return 1
+  }
+
+  local ok
+  ok=$(echo "$result" | jq -r '.ok')
+  if [ "$ok" != "true" ]; then
+    log_error "sort_pbis_by_dependency: $(echo "$result" | jq -r '.error')"
+    return 1
+  fi
+
+  echo "$result" | jq '.result'
+}
+
+# ── Git manager ────────────────────────────────────────────────────────
+
+# Resolves the default/base branch name.
+# Priority: BASE_BRANCH config/CLI value > git symbolic-ref > error
+# Prints the branch name on success. Returns 1 on failure.
+detect_default_branch() {
+  if [ -n "$BASE_BRANCH" ]; then
+    echo "$BASE_BRANCH"
+    return 0
+  fi
+
+  local symbolic_ref
+  symbolic_ref=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) || {
+    log_error "detect_default_branch: cannot determine default branch — set baseBranch in config or --base-branch"
+    return 1
+  }
+  # symbolic_ref is like refs/remotes/origin/main → strip the prefix
+  echo "${symbolic_ref#refs/remotes/origin/}"
+}
+
+# Converts a Feature title to a URL-safe lowercase slug.
+# Replaces non-alphanumeric characters with hyphens, collapses runs,
+# and strips leading/trailing hyphens.
+# Usage: slugify_title <title>
+# Prints the slug.
+slugify_title() {
+  local title="$1"
+  printf '%s' "$title" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9]/-/g' \
+    | sed 's/-\+/-/g' \
+    | sed 's/^-//;s/-$//'
+}
+
+# Creates a feature branch named agent/<feature_id>-<slug> from the base branch
+# and pushes it to origin.
+# Usage: create_feature_branch <feature_id> <feature_title>
+# Prints the branch name on success. Returns 1 on failure.
+create_feature_branch() {
+  local feature_id="$1"
+  local feature_title="$2"
+
+  local base_branch
+  base_branch=$(detect_default_branch) || return 1
+
+  local slug
+  slug=$(slugify_title "$feature_title")
+  local branch_name="agent/${feature_id}-${slug}"
+
+  log_info "Creating branch '$branch_name' from '$base_branch'"
+
+  git fetch origin "$base_branch" 2>&1 | while IFS= read -r line; do log_info "git: $line"; done
+  if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+    log_error "create_feature_branch: failed to fetch '$base_branch' from origin"
+    return 1
+  fi
+
+  if git show-ref --verify --quiet "refs/heads/$branch_name"; then
+    log_info "Branch '$branch_name' already exists locally — checking out"
+    git checkout "$branch_name" 2>&1 | while IFS= read -r line; do log_info "git: $line"; done
+    if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+      log_error "create_feature_branch: failed to checkout existing branch '$branch_name'"
+      return 1
+    fi
+  else
+    git checkout -b "$branch_name" "origin/$base_branch" 2>&1 | while IFS= read -r line; do log_info "git: $line"; done
+    if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+      log_error "create_feature_branch: failed to create branch '$branch_name'"
+      return 1
+    fi
+  fi
+
+  git push -u origin "$branch_name" 2>&1 | while IFS= read -r line; do log_info "git: $line"; done
+  if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+    log_error "create_feature_branch: failed to push '$branch_name' to origin"
+    return 1
+  fi
+
+  log_info "Branch '$branch_name' created and pushed to origin"
+  printf '%s\n' "$branch_name"
+}
+
+# Verifies that the working tree is clean (no uncommitted changes) and that
+# all commits on the feature branch have been pushed to origin.
+# Usage: check_clean_and_pushed <feature_branch>
+# Returns 0 if both conditions hold, 1 otherwise.
+check_clean_and_pushed() {
+  local feature_branch="$1"
+
+  local status_output
+  status_output=$(git status --porcelain 2>&1)
+  if [ -n "$status_output" ]; then
+    log_error "check_clean_and_pushed: working tree is not clean — uncommitted changes detected"
+    log_error "$status_output"
+    return 1
+  fi
+
+  # Fetch to make sure remote tracking ref is current.
+  git fetch origin "$feature_branch" 2>/dev/null || true
+
+  local unpushed
+  unpushed=$(git log "origin/${feature_branch}..HEAD" --oneline 2>/dev/null)
+  if [ -n "$unpushed" ]; then
+    log_error "check_clean_and_pushed: there are unpushed commits on '$feature_branch':"
+    log_error "$unpushed"
+    return 1
+  fi
+
+  return 0
+}
+
+trap 'release_lock; cleanup' EXIT
+
+acquire_lock
+ensure_gitignore
+
+# ── Agent dispatcher ───────────────────────────────────────────────────
+
+# Assembles the prompt that will be sent to the AI agent.
+# The prompt includes PBI title, description, and acceptance criteria,
+# plus instructions to read feature context and signal completion.
+# Usage: build_prompt <pbi_title> <pbi_description> <acceptance_criteria>
+# Prints the assembled prompt string.
+build_prompt() {
+  local pbi_title="$1"
+  local pbi_description="$2"
+  local acceptance_criteria="$3"
+
+  cat <<PROMPT
+You are an autonomous software development agent implementing a Product Backlog Item (PBI).
+
+## PBI Details
+
+**Title:** ${pbi_title}
+
+**Description:**
+${pbi_description}
+
+**Acceptance Criteria:**
+${acceptance_criteria}
+
+## Feature Context
+
+Read the file \`.agent-context/feature.md\` in your working directory for additional context about the parent Feature this PBI belongs to.
+
+## Instructions
+
+1. Implement the PBI described above, satisfying all acceptance criteria.
+2. Write, edit, and test code as needed using the tools available to you.
+3. Commit your changes with a clear commit message referencing the work done.
+4. Push the commit to the remote origin. Do NOT create a pull request.
+5. When you have finished implementing and pushing all changes, output the exact string \`AGENT_COMPLETE\` on a line by itself to signal completion.
+PROMPT
+}
+
+# Dispatches the configured AI provider with the given prompt and captures output.
+# Globals set after return:
+#   AGENT_INVOKE_EXIT_CODE  — exit code from the agent process
+#   AGENT_INVOKE_COMPLETED  — "true" if AGENT_COMPLETE was detected in output, else "false"
+# Usage: invoke_agent <prompt>
+# Prints the captured agent output (stdout + stderr combined).
+# Returns 1 if provider is invalid, otherwise returns 0 regardless of agent exit code
+# (the caller should inspect AGENT_INVOKE_EXIT_CODE for the agent's own exit status).
+invoke_agent() {
+  local prompt="$1"
+  local output=""
+  local exit_code=0
+
+  AGENT_INVOKE_EXIT_CODE=0
+  AGENT_INVOKE_COMPLETED="false"
+
+  case "$PROVIDER" in
+    claude-code)
+      local model_args=()
+      if [ -n "$MODEL" ]; then
+        model_args=(--model "$MODEL")
+      fi
+      output=$(claude -p "$prompt" \
+        --output-format json \
+        "${model_args[@]}" \
+        --allowedTools "Read,Write,Edit,Bash" \
+        --max-turns "$MAX_ITERATIONS" 2>&1) || exit_code=$?
+      ;;
+    cursor-cli)
+      output=$(agent -p "$prompt" --force --output-format json 2>&1) || exit_code=$?
+      ;;
+    *)
+      log_error "invoke_agent: unknown provider '$PROVIDER'. Must be 'claude-code' or 'cursor-cli'."
+      return 1
+      ;;
+  esac
+
+  AGENT_INVOKE_EXIT_CODE=$exit_code
+
+  if printf '%s' "$output" | grep -qF 'AGENT_COMPLETE'; then
+    AGENT_INVOKE_COMPLETED="true"
+  fi
+
+  if [ "$exit_code" -ne 0 ]; then
+    log_error "invoke_agent: agent exited with non-zero exit code $exit_code"
+  fi
+
+  printf '%s' "$output"
+}
+
+# ── Inner Ralph loop ───────────────────────────────────────────────────
+
+# Inner loop that processes a single PBI through repeated agent invocations
+# until the work is verifiably complete or the max iteration limit is hit.
+#
+# Sets PBI state to "In Progress" before the first invocation. Each iteration
+# invokes the agent with a fresh context (no session resumption). The stop
+# condition requires BOTH an AGENT_COMPLETE signal AND a clean, fully-pushed
+# working tree. On success the PBI is tagged "agent-done"; on exhaustion or
+# agent error it is tagged "agent-failed".
+#
+# Usage: process_pbi <pbi_id> <pbi_title> <pbi_description> <acceptance_criteria> <feature_branch> <feature_id>
+# Returns 0 on success, 1 on failure.
+process_pbi() {
+  local pbi_id="$1"
+  local pbi_title="$2"
+  local pbi_description="$3"
+  local acceptance_criteria="$4"
+  local feature_branch="$5"
+  local feature_id="$6"
+
+  log_info "Starting inner loop for PBI $pbi_id: $pbi_title"
+
+  # Set PBI state to "In Progress" before first agent invocation.
+  update_work_item_state "$pbi_id" "In Progress" || {
+    log_error "process_pbi: failed to set PBI $pbi_id to 'In Progress' — aborting"
+    return 1
+  }
+
+  local prompt
+  prompt=$(build_prompt "$pbi_title" "$pbi_description" "$acceptance_criteria")
+
+  local iteration=1
+  while [ "$iteration" -le "$MAX_ITERATIONS" ]; do
+    log_info "Iteration ${iteration}/${MAX_ITERATIONS} for PBI ${pbi_id}"
+
+    local agent_output
+    agent_output=$(invoke_agent "$prompt")
+
+    # Capture agent output to the context log for this feature.
+    capture_agent_log "$feature_id" "$agent_output"
+
+    # Stop condition: AGENT_COMPLETE signal AND clean+pushed working tree.
+    if [ "$AGENT_INVOKE_COMPLETED" = "true" ] && check_clean_and_pushed "$feature_branch"; then
+      log_info "PBI $pbi_id completed successfully after $iteration iteration(s)"
+      add_work_item_tag "$pbi_id" "agent-done" || log_warn "process_pbi: failed to tag PBI $pbi_id as agent-done"
+      return 0
+    fi
+
+    # If the agent process itself errored, stop retrying immediately.
+    if [ "$AGENT_INVOKE_EXIT_CODE" -ne 0 ]; then
+      log_error "process_pbi: agent exited with code $AGENT_INVOKE_EXIT_CODE on iteration $iteration — stopping"
+      break
+    fi
+
+    iteration=$((iteration + 1))
+  done
+
+  log_error "process_pbi: PBI $pbi_id did not complete within $MAX_ITERATIONS iteration(s)"
+  add_work_item_tag "$pbi_id" "agent-failed" || log_warn "process_pbi: failed to tag PBI $pbi_id as agent-failed"
+  return 1
+}
+
+# ── Orchestrator ──────────────────────────────────────────────────────
+
+log_info "agent-loop started"
+
+# Step 3/4: Determine the Feature to process
+if [ -n "$FEATURE_ID" ]; then
+  # One-shot mode: --feature-id was supplied
+  log_info "One-shot mode: processing Feature $FEATURE_ID"
+  FEATURE_JSON=$(get_work_item "$FEATURE_ID") || {
+    log_error "Failed to fetch Feature $FEATURE_ID"
+    exit 1
+  }
+else
+  # Scheduled mode: pick the first eligible Feature
+  log_info "Scheduled mode: querying for eligible Features"
+  ELIGIBLE_IDS=$(query_eligible_features) || {
+    log_error "Failed to query eligible Features"
+    exit 1
+  }
+
+  if [ -z "$ELIGIBLE_IDS" ]; then
+    log_info "No eligible Features found — nothing to do"
+    exit 0
+  fi
+
+  FEATURE_ID=$(echo "$ELIGIBLE_IDS" | head -n1)
+  log_info "Selected Feature $FEATURE_ID for processing"
+
+  FEATURE_JSON=$(get_work_item "$FEATURE_ID") || {
+    log_error "Failed to fetch Feature $FEATURE_ID"
+    exit 1
+  }
+fi
+
+FEATURE_TITLE=$(printf '%s' "$FEATURE_JSON" | jq -r '.fields["System.Title"] // ""')
+FEATURE_DESCRIPTION=$(printf '%s' "$FEATURE_JSON" | jq -r '.fields["System.Description"] // ""')
+
+log_info "Processing Feature $FEATURE_ID: $FEATURE_TITLE"
+
+# Step 5: Fetch all child PBIs
+log_info "Fetching child PBIs for Feature $FEATURE_ID"
+PBIS_JSON=$(get_child_pbis "$FEATURE_ID") || {
+  log_error "Failed to fetch child PBIs for Feature $FEATURE_ID"
+  exit 1
+}
+
+PBI_COUNT=$(printf '%s' "$PBIS_JSON" | jq 'length')
+if [ "$PBI_COUNT" -eq 0 ]; then
+  log_info "Feature $FEATURE_ID has no child PBIs — nothing to do"
+  exit 0
+fi
+log_info "Found $PBI_COUNT PBI(s) for Feature $FEATURE_ID"
+
+# Step 6: Topologically sort PBIs by dependency
+log_info "Sorting PBIs by dependency order"
+SORTED_PBIS=$(sort_pbis_by_dependency "$PBIS_JSON") || {
+  log_error "Failed to sort PBIs by dependency for Feature $FEATURE_ID"
+  exit 1
+}
+
+# Step 7: Create feature branch
+log_info "Creating feature branch for Feature $FEATURE_ID"
+FEATURE_BRANCH=$(create_feature_branch "$FEATURE_ID" "$FEATURE_TITLE") || {
+  log_error "Failed to create feature branch for Feature $FEATURE_ID"
+  exit 1
+}
+
+# Step 8: Write Feature PRD to .agent-context/feature.md
+write_feature_context "$FEATURE_ID" "# Feature: $FEATURE_TITLE
+
+## Description
+$FEATURE_DESCRIPTION"
+
+# Step 9/10: Process each PBI serially; stop on first failure
+FEATURE_SUCCESS=true
+for i in $(seq 0 $((PBI_COUNT - 1))); do
+  PBI_JSON=$(printf '%s' "$SORTED_PBIS" | jq ".[$i]")
+  PBI_ID=$(printf '%s' "$PBI_JSON" | jq -r '.id')
+  PBI_TITLE=$(printf '%s' "$PBI_JSON" | jq -r '.fields["System.Title"] // ""')
+  PBI_DESCRIPTION=$(printf '%s' "$PBI_JSON" | jq -r '.fields["System.Description"] // ""')
+  PBI_AC=$(printf '%s' "$PBI_JSON" | jq -r '.fields["Microsoft.VSTS.Common.AcceptanceCriteria"] // ""')
+
+  log_info "Starting PBI $PBI_ID: $PBI_TITLE"
+
+  if ! process_pbi "$PBI_ID" "$PBI_TITLE" "$PBI_DESCRIPTION" "$PBI_AC" "$FEATURE_BRANCH" "$FEATURE_ID"; then
+    log_error "PBI $PBI_ID failed — skipping remaining PBIs for Feature $FEATURE_ID"
+    FEATURE_SUCCESS=false
+    break
+  fi
+
+  log_info "PBI $PBI_ID completed"
+done
+
+# Step 11: Create PR only when all PBIs are tagged agent-done
+if [ "$FEATURE_SUCCESS" = "true" ]; then
+  log_info "All PBIs completed — creating pull request for Feature $FEATURE_ID"
+  PR_URL=$(create_pull_request "$FEATURE_TITLE" "$FEATURE_BRANCH" "$SORTED_PBIS") || {
+    log_error "Failed to create pull request for Feature $FEATURE_ID"
+    exit 1
+  }
+  log_info "Feature $FEATURE_ID complete — PR: $PR_URL"
+  exit 0
+else
+  log_error "Feature $FEATURE_ID processing failed — one or more PBIs did not complete"
+  exit 1
+fi

--- a/agent-loop/agent-loop.sh
+++ b/agent-loop/agent-loop.sh
@@ -378,6 +378,15 @@ get_work_item() {
   _ado_call GET "$url"
 }
 
+# Returns the "in progress" state name for the configured process template.
+# Scrum → "In Progress"; Agile/CMMI → "Active"; unknown → "In Progress".
+get_in_progress_state() {
+  case "${PROCESS:-}" in
+    Agile|CMMI) echo "Active" ;;
+    *)          echo "In Progress" ;;
+  esac
+}
+
 # Transitions a work item to the given state.
 # The caller is responsible for passing the correct state name for the process
 # template (e.g. "Active" for Agile, "In Progress" for Scrum).
@@ -800,9 +809,11 @@ process_pbi() {
 
   log_info "Starting inner loop for PBI $pbi_id: $pbi_title"
 
-  # Set PBI state to "In Progress" before first agent invocation.
-  update_work_item_state "$pbi_id" "In Progress" || {
-    log_error "process_pbi: failed to set PBI $pbi_id to 'In Progress' — aborting"
+  # Set PBI state to the process-appropriate in-progress state before first agent invocation.
+  local in_progress_state
+  in_progress_state=$(get_in_progress_state)
+  update_work_item_state "$pbi_id" "$in_progress_state" || {
+    log_error "process_pbi: failed to set PBI $pbi_id to '$in_progress_state' — aborting"
     return 1
   }
 

--- a/agent-loop/agent-loop.sh
+++ b/agent-loop/agent-loop.sh
@@ -58,8 +58,8 @@ Options:
   --team <name>             Azure DevOps team name
   --process <template>      Process template: Scrum, Agile, or CMMI
   --repo-url <url>          Git repository URL
-  --base-branch <branch>    Base branch to branch from (default: main)
-  --max-iterations <n>      Maximum loop iterations (default: 50)
+  --base-branch <branch>    Base branch (auto-detected from git if omitted)
+  --max-iterations <n>      Max agent invocations per PBI (default: 5)
   --provider <name>         AI provider: claude-code or cursor-cli
   --model <id>              Model ID to use (e.g. claude-opus-4-6)
   --working-directory <dir> Working directory containing the repo
@@ -67,8 +67,8 @@ Options:
 
 Environment variables:
   AZURE_DEVOPS_PAT          Required. Azure DevOps Personal Access Token.
-  ANTHROPIC_API_KEY         Required when --provider is anthropic.
-  CURSOR_API_KEY            Required when --provider is cursor.
+  ANTHROPIC_API_KEY         Required when --provider is claude-code.
+  CURSOR_API_KEY            Required when --provider is cursor-cli.
 
 Config file:
   .agent-loop.json          Optional JSON config in the working directory.
@@ -110,14 +110,14 @@ if [ -f "$CONFIG_FILE" ]; then
     exit 1
   fi
 
-  CONFIG_ORG=$(jq -r '.org // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_ORG=$(jq -r '.organizationUrl // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_PROJECT=$(jq -r '.project // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_AREA_PATH=$(jq -r '.areaPath // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_TEAM=$(jq -r '.team // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_PROCESS=$(jq -r '.process // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_REPO_URL=$(jq -r '.repoUrl // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_REPO_URL=$(jq -r '.repositoryUrl // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_BASE_BRANCH=$(jq -r '.baseBranch // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_MAX_ITERATIONS=$(jq -r '.maxIterations // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_MAX_ITERATIONS=$(jq -r '.maxIterationsPerPbi // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_PROVIDER=$(jq -r '.provider // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_MODEL=$(jq -r '.model // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_WORKING_DIRECTORY=$(jq -r '.workingDirectory // empty' "$CONFIG_FILE" 2>/dev/null || true)
@@ -131,8 +131,8 @@ AREA_PATH="${CLI_AREA_PATH:-$CONFIG_AREA_PATH}"
 TEAM="${CLI_TEAM:-$CONFIG_TEAM}"
 PROCESS="${CLI_PROCESS:-$CONFIG_PROCESS}"
 REPO_URL="${CLI_REPO_URL:-$CONFIG_REPO_URL}"
-BASE_BRANCH="${CLI_BASE_BRANCH:-${CONFIG_BASE_BRANCH:-main}}"
-MAX_ITERATIONS="${CLI_MAX_ITERATIONS:-${CONFIG_MAX_ITERATIONS:-50}}"
+BASE_BRANCH="${CLI_BASE_BRANCH:-${CONFIG_BASE_BRANCH:-}}"
+MAX_ITERATIONS="${CLI_MAX_ITERATIONS:-${CONFIG_MAX_ITERATIONS:-5}}"
 PROVIDER="${CLI_PROVIDER:-$CONFIG_PROVIDER}"
 MODEL="${CLI_MODEL:-$CONFIG_MODEL}"
 FEATURE_ID="${CLI_FEATURE_ID:-$CONFIG_FEATURE_ID}"
@@ -203,8 +203,8 @@ echo "  agent-loop"
 echo "  Org:             $ORG"
 echo "  Project:         $PROJECT"
 echo "  Provider:        $PROVIDER${MODEL:+ ($MODEL)}"
-echo "  Base branch:     $BASE_BRANCH"
-echo "  Max iterations:  $MAX_ITERATIONS"
+echo "  Base branch:     ${BASE_BRANCH:-(auto-detect)}"
+echo "  Max iter/PBI:    $MAX_ITERATIONS"
 [ -n "$FEATURE_ID" ] && echo "  Feature ID:      $FEATURE_ID"
 [ -n "$AREA_PATH" ]  && echo "  Area path:       $AREA_PATH"
 [ -n "$TEAM" ]       && echo "  Team:            $TEAM"
@@ -234,10 +234,13 @@ AGENT_CONTEXT_DIR="$WORKING_DIR/.agent-context"
 
 ensure_gitignore() {
   local gitignore="$WORKING_DIR/.gitignore"
-  if [ ! -f "$gitignore" ] || ! grep -qxF '.agent-context/' "$gitignore"; then
-    echo '.agent-context/' >> "$gitignore"
-    log_info ".agent-context/ added to .gitignore"
-  fi
+  local entries=('.agent-context/' '.agent-loop.lock')
+  for entry in "${entries[@]}"; do
+    if [ ! -f "$gitignore" ] || ! grep -qxF "$entry" "$gitignore"; then
+      echo "$entry" >> "$gitignore"
+      log_info "$entry added to .gitignore"
+    fi
+  done
 }
 
 write_feature_context() {
@@ -697,6 +700,14 @@ trap 'release_lock; cleanup' EXIT
 acquire_lock
 ensure_gitignore
 
+# Resolve base branch early (auto-detect if not configured) so it is
+# available to both create_feature_branch and create_pull_request.
+BASE_BRANCH=$(detect_default_branch) || {
+  log_error "Failed to determine base branch"
+  exit 1
+}
+log_info "Base branch resolved to '$BASE_BRANCH'"
+
 # ── Agent dispatcher ───────────────────────────────────────────────────
 
 # Assembles the prompt that will be sent to the AI agent.
@@ -761,8 +772,7 @@ invoke_agent() {
       output=$(claude -p "$prompt" \
         --output-format json \
         "${model_args[@]}" \
-        --allowedTools "Read,Write,Edit,Bash" \
-        --max-turns "$MAX_ITERATIONS" 2>&1) || exit_code=$?
+        --allowedTools "Read,Write,Edit,Bash" 2>&1) || exit_code=$?
       ;;
     cursor-cli)
       output=$(agent -p "$prompt" --force --output-format json 2>&1) || exit_code=$?
@@ -897,12 +907,18 @@ PBIS_JSON=$(get_child_pbis "$FEATURE_ID") || {
   exit 1
 }
 
+# Filter to only PBIs tagged "ready-for-agent" in "New" state.
+PBIS_JSON=$(printf '%s' "$PBIS_JSON" | jq '[.[] | select(
+  ((.fields["System.Tags"] // "") | contains("ready-for-agent"))
+  and .fields["System.State"] == "New"
+)]')
+
 PBI_COUNT=$(printf '%s' "$PBIS_JSON" | jq 'length')
 if [ "$PBI_COUNT" -eq 0 ]; then
-  log_info "Feature $FEATURE_ID has no child PBIs — nothing to do"
+  log_info "Feature $FEATURE_ID has no eligible child PBIs (ready-for-agent + New) — nothing to do"
   exit 0
 fi
-log_info "Found $PBI_COUNT PBI(s) for Feature $FEATURE_ID"
+log_info "Found $PBI_COUNT eligible PBI(s) for Feature $FEATURE_ID"
 
 # Step 6: Topologically sort PBIs by dependency
 log_info "Sorting PBIs by dependency order"

--- a/agent-loop/agent-loop.sh
+++ b/agent-loop/agent-loop.sh
@@ -18,6 +18,7 @@ CONFIG_MAX_ITERATIONS=""
 CONFIG_PROVIDER=""
 CONFIG_MODEL=""
 CONFIG_WORKING_DIRECTORY=""
+CONFIG_SYSTEM_LOG_DIRECTORY=""
 CONFIG_FEATURE_ID=""
 
 # ── CLI parameter parsing ─────────────────────────────────────────────
@@ -32,6 +33,7 @@ CLI_MAX_ITERATIONS=""
 CLI_PROVIDER=""
 CLI_MODEL=""
 CLI_WORKING_DIRECTORY=""
+CLI_SYSTEM_LOG_DIRECTORY=""
 CLI_FEATURE_ID=""
 
 # ── Logging ───────────────────────────────────────────────────────────
@@ -63,6 +65,8 @@ Options:
   --provider <name>         AI provider: claude-code or cursor-cli
   --model <id>              Model ID to use (e.g. claude-opus-4-6)
   --working-directory <dir> Working directory containing the repo
+  --system-log-directory <dir>
+                            Persistent system-level directory for retained agent logs
   --feature-id <id>         ADO Feature ID to process (optional; processes all if omitted)
 
 Environment variables:
@@ -76,20 +80,39 @@ Config file:
 EOF
 }
 
+require_option_value() {
+  local option="$1"
+  local value="${2-}"
+  if [ -z "$value" ] || [[ "$value" == --* ]]; then
+    echo "Error: $option requires a value." >&2
+    print_usage >&2
+    exit 1
+  fi
+}
+
+resolve_system_log_directory() {
+  case "$(uname -s)" in
+    Darwin) printf '%s\n' "${HOME}/Library/Logs/agent-loop" ;;
+    Linux)  printf '%s\n' "${XDG_STATE_HOME:-${HOME}/.local/state}/agent-loop/logs" ;;
+    *)      printf '%s\n' "${HOME}/.agent-loop/logs" ;;
+  esac
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --org)              CLI_ORG="$2";               shift 2 ;;
-    --project)          CLI_PROJECT="$2";           shift 2 ;;
-    --area-path)        CLI_AREA_PATH="$2";         shift 2 ;;
-    --team)             CLI_TEAM="$2";              shift 2 ;;
-    --process)          CLI_PROCESS="$2";           shift 2 ;;
-    --repo-url)         CLI_REPO_URL="$2";          shift 2 ;;
-    --base-branch)      CLI_BASE_BRANCH="$2";       shift 2 ;;
-    --max-iterations)   CLI_MAX_ITERATIONS="$2";    shift 2 ;;
-    --provider)         CLI_PROVIDER="$2";          shift 2 ;;
-    --model)            CLI_MODEL="$2";             shift 2 ;;
-    --working-directory) CLI_WORKING_DIRECTORY="$2"; shift 2 ;;
-    --feature-id)       CLI_FEATURE_ID="$2";        shift 2 ;;
+    --org)              require_option_value "$1" "${2-}"; CLI_ORG="$2";                shift 2 ;;
+    --project)          require_option_value "$1" "${2-}"; CLI_PROJECT="$2";            shift 2 ;;
+    --area-path)        require_option_value "$1" "${2-}"; CLI_AREA_PATH="$2";          shift 2 ;;
+    --team)             require_option_value "$1" "${2-}"; CLI_TEAM="$2";               shift 2 ;;
+    --process)          require_option_value "$1" "${2-}"; CLI_PROCESS="$2";            shift 2 ;;
+    --repo-url)         require_option_value "$1" "${2-}"; CLI_REPO_URL="$2";           shift 2 ;;
+    --base-branch)      require_option_value "$1" "${2-}"; CLI_BASE_BRANCH="$2";        shift 2 ;;
+    --max-iterations)   require_option_value "$1" "${2-}"; CLI_MAX_ITERATIONS="$2";     shift 2 ;;
+    --provider)         require_option_value "$1" "${2-}"; CLI_PROVIDER="$2";           shift 2 ;;
+    --model)            require_option_value "$1" "${2-}"; CLI_MODEL="$2";              shift 2 ;;
+    --working-directory) require_option_value "$1" "${2-}"; CLI_WORKING_DIRECTORY="$2"; shift 2 ;;
+    --system-log-directory) require_option_value "$1" "${2-}"; CLI_SYSTEM_LOG_DIRECTORY="$2"; shift 2 ;;
+    --feature-id)       require_option_value "$1" "${2-}"; CLI_FEATURE_ID="$2";         shift 2 ;;
     --help|-h)          print_usage; exit 0 ;;
     *)
       echo "Error: Unknown option: $1" >&2
@@ -101,8 +124,9 @@ done
 
 # ── Load config file ──────────────────────────────────────────────────
 # Resolve working directory: CLI > env > current directory
-WORKING_DIR="${CLI_WORKING_DIRECTORY:-${AGENT_LOOP_WORKING_DIRECTORY:-$(pwd)}}"
-CONFIG_FILE="$WORKING_DIR/.agent-loop.json"
+INITIAL_WORKING_DIR="${CLI_WORKING_DIRECTORY:-${AGENT_LOOP_WORKING_DIRECTORY:-$(pwd)}}"
+WORKING_DIR="$INITIAL_WORKING_DIR"
+CONFIG_FILE="$INITIAL_WORKING_DIR/.agent-loop.json"
 
 if [ -f "$CONFIG_FILE" ]; then
   if ! command -v jq &>/dev/null; then
@@ -121,6 +145,7 @@ if [ -f "$CONFIG_FILE" ]; then
   CONFIG_PROVIDER=$(jq -r '.provider // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_MODEL=$(jq -r '.model // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_WORKING_DIRECTORY=$(jq -r '.workingDirectory // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_SYSTEM_LOG_DIRECTORY=$(jq -r '.systemLogDirectory // empty' "$CONFIG_FILE" 2>/dev/null || true)
   CONFIG_FEATURE_ID=$(jq -r '.featureId // empty' "$CONFIG_FILE" 2>/dev/null || true)
 fi
 
@@ -136,6 +161,8 @@ MAX_ITERATIONS="${CLI_MAX_ITERATIONS:-${CONFIG_MAX_ITERATIONS:-5}}"
 PROVIDER="${CLI_PROVIDER:-$CONFIG_PROVIDER}"
 MODEL="${CLI_MODEL:-$CONFIG_MODEL}"
 FEATURE_ID="${CLI_FEATURE_ID:-$CONFIG_FEATURE_ID}"
+WORKING_DIR="${CLI_WORKING_DIRECTORY:-${CONFIG_WORKING_DIRECTORY:-$INITIAL_WORKING_DIR}}"
+SYSTEM_LOG_DIR="${CLI_SYSTEM_LOG_DIRECTORY:-${CONFIG_SYSTEM_LOG_DIRECTORY:-${AGENT_LOOP_SYSTEM_LOG_DIR:-$(resolve_system_log_directory)}}}"
 
 # ── Validate required values ──────────────────────────────────────────
 ERRORS=()
@@ -158,6 +185,21 @@ fi
 # ── Validate provider value ───────────────────────────────────────────
 if [[ "$PROVIDER" != "claude-code" && "$PROVIDER" != "cursor-cli" ]]; then
   echo "Error: Invalid provider '$PROVIDER'. Must be 'claude-code' or 'cursor-cli'." >&2
+  exit 1
+fi
+
+if [[ ! "$MAX_ITERATIONS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: --max-iterations must be a positive integer." >&2
+  exit 1
+fi
+
+if [ ! -d "$WORKING_DIR" ]; then
+  echo "Error: working directory does not exist: $WORKING_DIR" >&2
+  exit 1
+fi
+
+if ! mkdir -p "$SYSTEM_LOG_DIR"; then
+  echo "Error: could not create system log directory: $SYSTEM_LOG_DIR" >&2
   exit 1
 fi
 
@@ -196,6 +238,7 @@ export AGENT_LOOP_MAX_ITERATIONS="$MAX_ITERATIONS"
 export AGENT_LOOP_PROVIDER="$PROVIDER"
 export AGENT_LOOP_MODEL="$MODEL"
 export AGENT_LOOP_WORKING_DIRECTORY="$WORKING_DIR"
+export AGENT_LOOP_SYSTEM_LOG_DIR="$SYSTEM_LOG_DIR"
 export AGENT_LOOP_FEATURE_ID="$FEATURE_ID"
 
 echo "══════════════════════════════════════════════════════"
@@ -209,21 +252,24 @@ echo "  Max iter/PBI:    $MAX_ITERATIONS"
 [ -n "$AREA_PATH" ]  && echo "  Area path:       $AREA_PATH"
 [ -n "$TEAM" ]       && echo "  Team:            $TEAM"
 [ -n "$REPO_URL" ]   && echo "  Repo URL:        $REPO_URL"
+echo "  System logs:     $SYSTEM_LOG_DIR"
 echo "══════════════════════════════════════════════════════"
 
 # ── Lock manager ──────────────────────────────────────────────────────
 LOCK_FILE="$WORKING_DIR/.agent-loop.lock"
+LOCK_ACQUIRED=false
 
 acquire_lock() {
   if ! ( set -o noclobber; echo "$$" > "$LOCK_FILE" ) 2>/dev/null; then
     log_warn "Another instance is already running (lock file exists: $LOCK_FILE). Exiting."
-    exit 0
+    return 1
   fi
+  LOCK_ACQUIRED=true
   log_info "Lock acquired: $LOCK_FILE"
 }
 
 release_lock() {
-  if [ -f "$LOCK_FILE" ]; then
+  if [ "$LOCK_ACQUIRED" = true ] && [ -f "$LOCK_FILE" ] && [ "$(tr -d '[:space:]' < "$LOCK_FILE" 2>/dev/null)" = "$$" ]; then
     rm -f "$LOCK_FILE"
     log_info "Lock released: $LOCK_FILE"
   fi
@@ -231,6 +277,7 @@ release_lock() {
 
 # ── Context manager ───────────────────────────────────────────────────
 AGENT_CONTEXT_DIR="$WORKING_DIR/.agent-context"
+CURRENT_FEATURE_LOG_FILE=""
 
 ensure_gitignore() {
   local gitignore="$WORKING_DIR/.gitignore"
@@ -256,6 +303,33 @@ capture_agent_log() {
   local output="$2"
   mkdir -p "$AGENT_CONTEXT_DIR/logs"
   printf '%s\n' "$output" >> "$AGENT_CONTEXT_DIR/logs/feature-${feature_id}.log"
+  if [ -n "$CURRENT_FEATURE_LOG_FILE" ]; then
+    printf '%s\n' "$output" >> "$CURRENT_FEATURE_LOG_FILE"
+  fi
+}
+
+start_feature_log() {
+  local feature_id="$1"
+  local feature_title="$2"
+  local timestamp
+  timestamp=$(date -u '+%Y%m%dT%H%M%SZ')
+  CURRENT_FEATURE_LOG_FILE="$SYSTEM_LOG_DIR/feature-${feature_id}-${timestamp}.log"
+  {
+    printf 'Feature ID: %s\n' "$feature_id"
+    printf 'Feature Title: %s\n' "$feature_title"
+    printf 'Started At (UTC): %s\n' "$(date -u '+%Y-%m-%d %H:%M:%S')"
+    printf 'Working Directory: %s\n' "$WORKING_DIR"
+    printf 'Provider: %s%s\n' "$PROVIDER" "${MODEL:+ ($MODEL)}"
+    printf '\n'
+  } >> "$CURRENT_FEATURE_LOG_FILE"
+  log_info "Persistent agent log: $CURRENT_FEATURE_LOG_FILE"
+}
+
+append_feature_log_note() {
+  local message="$1"
+  if [ -n "$CURRENT_FEATURE_LOG_FILE" ]; then
+    printf '[%s] %s\n' "$(date -u '+%Y-%m-%d %H:%M:%S')" "$message" >> "$CURRENT_FEATURE_LOG_FILE"
+  fi
 }
 
 cleanup() {
@@ -319,7 +393,8 @@ _ado_call() {
 query_eligible_features() {
   local wiql="SELECT [System.Id] FROM WorkItemLinks WHERE [Source].[System.WorkItemType] = 'Feature'"
   if [ -n "$AREA_PATH" ]; then
-    wiql+=" AND [Source].[System.AreaPath] UNDER '$AREA_PATH'"
+    local escaped_area_path=${AREA_PATH//\'/\'\'}
+    wiql+=" AND [Source].[System.AreaPath] UNDER '$escaped_area_path'"
   fi
   wiql+=" AND [Target].[System.Tags] CONTAINS 'ready-for-agent' AND [Target].[System.State] = 'New' AND [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward' MODE (MustContain)"
 
@@ -399,7 +474,7 @@ update_work_item_state() {
   local state="$2"
 
   local payload
-  payload=$(jq -n --arg s "$state" '[{"op":"add","path":"/fields/System.State","value":$s}]')
+  payload=$(jq -n --arg s "$state" '[{"op":"replace","path":"/fields/System.State","value":$s}]')
 
   local url="${ORG}/${PROJECT}/_apis/wit/workitems/${work_item_id}?api-version=7.1"
   _ado_call PATCH "$url" "$payload" "application/json-patch+json" || return 1
@@ -420,14 +495,20 @@ add_work_item_tag() {
   current_tags=$(echo "$work_item" | jq -r '.fields["System.Tags"] // ""')
 
   local new_tags
+  local op="replace"
+  if printf '%s' "$current_tags" | jq -Rr --arg tag "$tag" 'split(";") | map(gsub("^\\s+|\\s+$"; "")) | any(. == $tag)' | grep -qx 'true'; then
+    log_info "Tag '$tag' already present on work item $work_item_id"
+    return 0
+  fi
   if [ -z "$current_tags" ]; then
     new_tags="$tag"
+    op="add"
   else
     new_tags="${current_tags}; ${tag}"
   fi
 
   local payload
-  payload=$(jq -n --arg t "$new_tags" '[{"op":"add","path":"/fields/System.Tags","value":$t}]')
+  payload=$(jq -n --arg op "$op" --arg t "$new_tags" '[{"op":$op,"path":"/fields/System.Tags","value":$t}]')
 
   local url="${ORG}/${PROJECT}/_apis/wit/workitems/${work_item_id}?api-version=7.1"
   _ado_call PATCH "$url" "$payload" "application/json-patch+json" || return 1
@@ -697,7 +778,9 @@ check_clean_and_pushed() {
 
 trap 'release_lock; cleanup' EXIT
 
-acquire_lock
+cd "$WORKING_DIR"
+
+acquire_lock || exit 0
 ensure_gitignore
 
 # Resolve base branch early (auto-detect if not configured) so it is
@@ -706,6 +789,7 @@ BASE_BRANCH=$(detect_default_branch) || {
   log_error "Failed to determine base branch"
   exit 1
 }
+export AGENT_LOOP_BASE_BRANCH="$BASE_BRANCH"
 log_info "Base branch resolved to '$BASE_BRANCH'"
 
 # ── Agent dispatcher ───────────────────────────────────────────────────
@@ -720,18 +804,25 @@ build_prompt() {
   local pbi_description="$2"
   local acceptance_criteria="$3"
 
-  cat <<PROMPT
+  cat <<'PROMPT'
 You are an autonomous software development agent implementing a Product Backlog Item (PBI).
 
 ## PBI Details
 
-**Title:** ${pbi_title}
+**Title:**
+PROMPT
+  printf '%s\n\n' "$pbi_title"
+  cat <<'PROMPT'
 
 **Description:**
-${pbi_description}
+PROMPT
+  printf '%s\n\n' "$pbi_description"
+  cat <<'PROMPT'
 
 **Acceptance Criteria:**
-${acceptance_criteria}
+PROMPT
+  printf '%s\n\n' "$acceptance_criteria"
+  cat <<'PROMPT'
 
 ## Feature Context
 
@@ -785,7 +876,7 @@ invoke_agent() {
 
   AGENT_INVOKE_EXIT_CODE=$exit_code
 
-  if printf '%s' "$output" | grep -qF 'AGENT_COMPLETE'; then
+  if printf '%s\n' "$output" | grep -qx 'AGENT_COMPLETE'; then
     AGENT_INVOKE_COMPLETED="true"
   fi
 
@@ -831,6 +922,7 @@ process_pbi() {
   prompt=$(build_prompt "$pbi_title" "$pbi_description" "$acceptance_criteria")
 
   local iteration=1
+  local failure_reason="did not complete within $MAX_ITERATIONS iteration(s)"
   while [ "$iteration" -le "$MAX_ITERATIONS" ]; do
     log_info "Iteration ${iteration}/${MAX_ITERATIONS} for PBI ${pbi_id}"
 
@@ -850,13 +942,14 @@ process_pbi() {
     # If the agent process itself errored, stop retrying immediately.
     if [ "$AGENT_INVOKE_EXIT_CODE" -ne 0 ]; then
       log_error "process_pbi: agent exited with code $AGENT_INVOKE_EXIT_CODE on iteration $iteration — stopping"
+      failure_reason="stopped after agent exit code $AGENT_INVOKE_EXIT_CODE on iteration $iteration"
       break
     fi
 
     iteration=$((iteration + 1))
   done
 
-  log_error "process_pbi: PBI $pbi_id did not complete within $MAX_ITERATIONS iteration(s)"
+  log_error "process_pbi: PBI $pbi_id $failure_reason"
   add_work_item_tag "$pbi_id" "agent-failed" || log_warn "process_pbi: failed to tag PBI $pbi_id as agent-failed"
   return 1
 }
@@ -895,10 +988,18 @@ else
   }
 fi
 
+FEATURE_TYPE=$(printf '%s' "$FEATURE_JSON" | jq -r '.fields["System.WorkItemType"] // ""')
+if [ "$FEATURE_TYPE" != "Feature" ]; then
+  log_error "Work item $FEATURE_ID is a '$FEATURE_TYPE', not a Feature"
+  exit 1
+fi
+
 FEATURE_TITLE=$(printf '%s' "$FEATURE_JSON" | jq -r '.fields["System.Title"] // ""')
 FEATURE_DESCRIPTION=$(printf '%s' "$FEATURE_JSON" | jq -r '.fields["System.Description"] // ""')
 
 log_info "Processing Feature $FEATURE_ID: $FEATURE_TITLE"
+start_feature_log "$FEATURE_ID" "$FEATURE_TITLE"
+append_feature_log_note "Feature processing started"
 
 # Step 5: Fetch all child PBIs
 log_info "Fetching child PBIs for Feature $FEATURE_ID"
@@ -909,7 +1010,10 @@ PBIS_JSON=$(get_child_pbis "$FEATURE_ID") || {
 
 # Filter to only PBIs tagged "ready-for-agent" in "New" state.
 PBIS_JSON=$(printf '%s' "$PBIS_JSON" | jq '[.[] | select(
-  ((.fields["System.Tags"] // "") | contains("ready-for-agent"))
+  ((.fields["System.Tags"] // "")
+    | split(";")
+    | map(gsub("^\\s+|\\s+$"; ""))
+    | any(. == "ready-for-agent"))
   and .fields["System.State"] == "New"
 )]')
 
@@ -965,11 +1069,14 @@ if [ "$FEATURE_SUCCESS" = "true" ]; then
   log_info "All PBIs completed — creating pull request for Feature $FEATURE_ID"
   PR_URL=$(create_pull_request "$FEATURE_TITLE" "$FEATURE_BRANCH" "$SORTED_PBIS") || {
     log_error "Failed to create pull request for Feature $FEATURE_ID"
+    append_feature_log_note "Failed to create pull request"
     exit 1
   }
+  append_feature_log_note "Feature completed successfully. Pull request: $PR_URL"
   log_info "Feature $FEATURE_ID complete — PR: $PR_URL"
   exit 0
 else
+  append_feature_log_note "Feature processing failed"
   log_error "Feature $FEATURE_ID processing failed — one or more PBIs did not complete"
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Adds `update_work_item_state` and `add_work_item_tag` functions to both `agent-loop.sh` and `agent-loop.ps1`
- Transitions PBI state to "In Progress" (or process-equivalent) when agent picks up a work item
- Appends `agent-done` or `agent-failed` tags on completion/failure without removing existing tags
- HTTP errors produce clear error messages via the logger

Closes #7

## Test plan

- [ ] Verify `update_work_item_state` PATCHes `System.State` correctly in both `.sh` and `.ps1`
- [ ] Verify `add_work_item_tag` appends without removing existing tags in both scripts
- [ ] Confirm state name resolves correctly for Agile ("Active") and Scrum ("In Progress") process templates
- [ ] Confirm HTTP errors surface clear messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)