### PR TITLE
Harden agent-loop processing and PR creation

### DIFF
--- a/agent-loop/README.md
+++ b/agent-loop/README.md
@@ -90,7 +90,7 @@ Useful optional values:
 
 Provider-specific environment variables:
 
-- `ANTHROPIC_API_KEY` when `provider` is `claude-code`
+- `ANTHROPIC_API_KEY` is optional when `provider` is `claude-code`; if set, Claude Code uses API-key auth instead of the signed-in Claude session
 - `CURSOR_API_KEY` when `provider` is `cursor-cli`
 
 ## Example Config
@@ -125,7 +125,9 @@ Run from the `agent-loop` folder, or pass `--working-directory` explicitly:
 
 ```bash
 export AZURE_DEVOPS_PAT=...
-export ANTHROPIC_API_KEY=...
+
+# Make sure `claude` is already signed in if using provider=claude-code.
+# Do not set ANTHROPIC_API_KEY if you want to use your Claude subscription.
 
 ./agent-loop.sh \
   --org "https://dev.azure.com/your-org" \
@@ -150,12 +152,11 @@ One-shot mode for a specific Feature:
 
 ```powershell
 $env:AZURE_DEVOPS_PAT = "..."
-$env:CURSOR_API_KEY = "..."
 
 ./agent-loop.ps1 `
   -Org "https://dev.azure.com/your-org" `
   -Project "Your Project" `
-  -Provider "cursor-cli" `
+  -Provider "claude-code" `
   -RepoUrl "https://dev.azure.com/your-org/Your%20Project/_git/your-repo" `
   -WorkingDirectory "/absolute/path/to/your/repo"
 ```
@@ -247,4 +248,5 @@ On failure, the scripts:
 
 - `repositoryUrl` is effectively required if you want automatic pull request creation.
 - If `baseBranch` is omitted, the scripts try to detect it from `origin/HEAD`.
+- `claude-code` does not require `ANTHROPIC_API_KEY` when the user is already logged into Claude Code. If `ANTHROPIC_API_KEY` is set, Claude Code will prefer the API key instead of the signed-in subscription session.
 - The Bash and PowerShell versions are intended to stay behaviorally aligned.

--- a/agent-loop/agent-loop.ps1
+++ b/agent-loop/agent-loop.ps1
@@ -31,7 +31,7 @@
   Max agent invocations per PBI (default: 5)
 
 .PARAMETER Provider
-  AI provider: claude-code or cursor-cli
+  AI provider: claude-code, cursor, or cursor-cli
 
 .PARAMETER Model
   Model ID to use (e.g. claude-opus-4-6)
@@ -45,8 +45,11 @@
 .NOTES
   Required environment variables:
     AZURE_DEVOPS_PAT     — Azure DevOps Personal Access Token
-    ANTHROPIC_API_KEY    — Required when -Provider is claude-code
-    CURSOR_API_KEY       — Required when -Provider is cursor-cli
+    ANTHROPIC_API_KEY    — Optional when -Provider is claude-code;
+                           if set, Claude Code uses API-key auth instead of
+                           the signed-in Claude session
+    CURSOR_API_KEY       — Optional when -Provider is cursor/cursor-cli;
+                           if omitted, the signed-in Cursor session is used
 #>
 
 [CmdletBinding()]
@@ -85,7 +88,33 @@ function log_warn {
 function log_error {
     param([string]$Message)
     $ts = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss')
-    Write-Error "[$ts] [ERROR] $Message"
+    # Keep error logs non-terminating so callers can decide whether to throw,
+    # retry, tag a PBI as failed, or continue to cleanup.
+    Write-Error "[$ts] [ERROR] $Message" -ErrorAction Continue
+}
+
+function Format-CommandArgument {
+    param([string]$Value)
+
+    if ($null -eq $Value) {
+        return "''"
+    }
+
+    if ($Value -match '[\s"`$]') {
+        return '"' + ($Value -replace '"', '\"') + '"'
+    }
+
+    return $Value
+}
+
+function Write-CommandLog {
+    param(
+        [string]$Prefix,
+        [string[]]$Arguments
+    )
+
+    $formatted = @($Arguments | ForEach-Object { Format-CommandArgument $_ }) -join ' '
+    log_info "$Prefix $formatted"
 }
 
 function Get-DefaultSystemLogDirectory {
@@ -106,37 +135,68 @@ function Get-DefaultSystemLogDirectory {
 }
 
 # ── Load config file ──────────────────────────────────────────────────
-# Resolve working directory: param > env > current directory
-$resolvedWorkingDir = if ($WorkingDirectory) {
+# Config can live alongside this script and/or in the target repo working directory.
+$configDirectory = if ($PSScriptRoot) {
+    $PSScriptRoot
+} else {
+    (Get-Location).Path
+}
+
+$fileConfig = @{}
+
+function Import-ConfigFile {
+    param(
+        [string]$ConfigFilePath,
+        [hashtable]$Config
+    )
+
+    if (-not (Test-Path $ConfigFilePath)) {
+        return
+    }
+
+    try {
+        $json = Get-Content $ConfigFilePath -Raw | ConvertFrom-Json
+        if ($null -ne $json.organizationUrl) { $Config['Org']              = $json.organizationUrl }
+        if ($null -ne $json.project)         { $Config['Project']          = $json.project }
+        if ($null -ne $json.areaPath)        { $Config['AreaPath']         = $json.areaPath }
+        if ($null -ne $json.team)            { $Config['Team']             = $json.team }
+        if ($null -ne $json.process)         { $Config['Process']          = $json.process }
+        if ($null -ne $json.repositoryUrl)   { $Config['RepoUrl']          = $json.repositoryUrl }
+        if ($null -ne $json.baseBranch)      { $Config['BaseBranch']       = $json.baseBranch }
+        if ($null -ne $json.maxIterationsPerPbi) { $Config['MaxIterations'] = $json.maxIterationsPerPbi }
+        if ($null -ne $json.provider)        { $Config['Provider']         = $json.provider }
+        if ($null -ne $json.model)           { $Config['Model']            = $json.model }
+        if ($null -ne $json.workingDirectory) { $Config['WorkingDirectory'] = $json.workingDirectory }
+        if ($null -ne $json.systemLogDirectory) { $Config['SystemLogDirectory'] = $json.systemLogDirectory }
+        if ($null -ne $json.featureId)       { $Config['FeatureId']        = [string]$json.featureId }
+    } catch {
+        Write-Error "Error: Failed to parse ${ConfigFilePath}: $_"
+        exit 1
+    }
+}
+
+$scriptConfigFile = Join-Path $configDirectory '.agent-loop.json'
+Import-ConfigFile -ConfigFilePath $scriptConfigFile -Config $fileConfig
+
+$candidateWorkingDir = if ($WorkingDirectory) {
     $WorkingDirectory
+} elseif ($fileConfig.ContainsKey('WorkingDirectory') -and $fileConfig['WorkingDirectory']) {
+    $fileConfig['WorkingDirectory']
 } elseif ($env:AGENT_LOOP_WORKING_DIRECTORY) {
     $env:AGENT_LOOP_WORKING_DIRECTORY
 } else {
     (Get-Location).Path
 }
 
-$configFile = Join-Path $resolvedWorkingDir '.agent-loop.json'
-$fileConfig = @{}
+if ($candidateWorkingDir) {
+    $workingConfigFile = Join-Path $candidateWorkingDir '.agent-loop.json'
+    $sameConfigFile = [System.StringComparer]::OrdinalIgnoreCase.Equals(
+        [System.IO.Path]::GetFullPath($scriptConfigFile),
+        [System.IO.Path]::GetFullPath($workingConfigFile)
+    )
 
-if (Test-Path $configFile) {
-    try {
-        $json = Get-Content $configFile -Raw | ConvertFrom-Json
-        if ($null -ne $json.organizationUrl) { $fileConfig['Org']              = $json.organizationUrl }
-        if ($null -ne $json.project)         { $fileConfig['Project']          = $json.project }
-        if ($null -ne $json.areaPath)        { $fileConfig['AreaPath']         = $json.areaPath }
-        if ($null -ne $json.team)            { $fileConfig['Team']             = $json.team }
-        if ($null -ne $json.process)         { $fileConfig['Process']          = $json.process }
-        if ($null -ne $json.repositoryUrl)   { $fileConfig['RepoUrl']          = $json.repositoryUrl }
-        if ($null -ne $json.baseBranch)      { $fileConfig['BaseBranch']       = $json.baseBranch }
-        if ($null -ne $json.maxIterationsPerPbi) { $fileConfig['MaxIterations'] = $json.maxIterationsPerPbi }
-        if ($null -ne $json.provider)        { $fileConfig['Provider']         = $json.provider }
-        if ($null -ne $json.model)           { $fileConfig['Model']            = $json.model }
-        if ($null -ne $json.workingDirectory) { $fileConfig['WorkingDirectory'] = $json.workingDirectory }
-        if ($null -ne $json.systemLogDirectory) { $fileConfig['SystemLogDirectory'] = $json.systemLogDirectory }
-        if ($null -ne $json.featureId)       { $fileConfig['FeatureId']        = [string]$json.featureId }
-    } catch {
-        Write-Error "Error: Failed to parse ${configFile}: $_"
-        exit 1
+    if (-not $sameConfigFile) {
+        Import-ConfigFile -ConfigFilePath $workingConfigFile -Config $fileConfig
     }
 }
 
@@ -148,6 +208,44 @@ function Resolve-Value {
     return $default
 }
 
+function Resolve-ProviderName {
+    param([string]$ProviderValue)
+
+    if (-not $ProviderValue) {
+        return $ProviderValue
+    }
+
+    switch ($ProviderValue.Trim().ToLowerInvariant()) {
+        'cursor' { return 'cursor-cli' }
+        'cursor-cli' { return 'cursor-cli' }
+        'claude-code' { return 'claude-code' }
+        default { return $ProviderValue }
+    }
+}
+
+function Resolve-CursorModel {
+    param(
+        [string]$ProviderValue,
+        [string]$ModelValue
+    )
+
+    if ($ProviderValue -ne 'cursor-cli' -or -not $ModelValue) {
+        return $ModelValue
+    }
+
+    $cursorModelAliases = @{
+        'claude-opus-4-6' = 'claude-4.6-opus-high-thinking'
+    }
+
+    if ($cursorModelAliases.ContainsKey($ModelValue)) {
+        $normalizedModel = $cursorModelAliases[$ModelValue]
+        log_info "Normalizing Cursor model '$ModelValue' to '$normalizedModel'."
+        return $normalizedModel
+    }
+
+    return $ModelValue
+}
+
 $resolvedOrg            = Resolve-Value $Org           'Org'
 $resolvedProject        = Resolve-Value $Project       'Project'
 $resolvedAreaPath       = Resolve-Value $AreaPath      'AreaPath'
@@ -156,14 +254,21 @@ $resolvedProcess        = Resolve-Value $Process       'Process'
 $resolvedRepoUrl        = Resolve-Value $RepoUrl       'RepoUrl'
 $resolvedBaseBranch     = Resolve-Value $BaseBranch    'BaseBranch'    $null
 $resolvedMaxIterations  = Resolve-Value $MaxIterations 'MaxIterations' 5
-$resolvedProvider       = Resolve-Value $Provider      'Provider'
+$resolvedProvider       = Resolve-ProviderName (Resolve-Value $Provider 'Provider')
 $resolvedModel          = Resolve-Value $Model         'Model'
 $resolvedFeatureId      = Resolve-Value $FeatureId     'FeatureId'
 $resolvedSystemLogDir   = Resolve-Value $SystemLogDirectory 'SystemLogDirectory'
-
-if (-not $WorkingDirectory -and -not $env:AGENT_LOOP_WORKING_DIRECTORY -and $fileConfig.ContainsKey('WorkingDirectory') -and $fileConfig['WorkingDirectory']) {
-    $resolvedWorkingDir = $fileConfig['WorkingDirectory']
+$resolvedWorkingDir     = if ($WorkingDirectory) {
+    $WorkingDirectory
+} elseif ($fileConfig.ContainsKey('WorkingDirectory') -and $fileConfig['WorkingDirectory']) {
+    $fileConfig['WorkingDirectory']
+} elseif ($env:AGENT_LOOP_WORKING_DIRECTORY) {
+    $env:AGENT_LOOP_WORKING_DIRECTORY
+} else {
+    (Get-Location).Path
 }
+
+$resolvedModel = Resolve-CursorModel $resolvedProvider $resolvedModel
 
 if (-not $resolvedSystemLogDir) {
     $resolvedSystemLogDir = if ($env:AGENT_LOOP_SYSTEM_LOG_DIR) { $env:AGENT_LOOP_SYSTEM_LOG_DIR } else { Get-DefaultSystemLogDirectory }
@@ -174,7 +279,7 @@ $errors = [System.Collections.Generic.List[string]]::new()
 
 if (-not $resolvedOrg)      { $errors.Add('Missing required value: -Org (Azure DevOps org URL)') }
 if (-not $resolvedProject)  { $errors.Add('Missing required value: -Project (Azure DevOps project name)') }
-if (-not $resolvedProvider) { $errors.Add('Missing required value: -Provider (claude-code or cursor-cli)') }
+if (-not $resolvedProvider) { $errors.Add('Missing required value: -Provider (claude-code, cursor, or cursor-cli)') }
 
 if ($errors.Count -gt 0) {
     Write-Host 'Error: Configuration is incomplete:' -ForegroundColor Red
@@ -182,14 +287,14 @@ if ($errors.Count -gt 0) {
         Write-Host "  - $err" -ForegroundColor Red
     }
     Write-Host ''
-    Write-Host 'Provide values via CLI parameters or .agent-loop.json in the working directory.' -ForegroundColor Yellow
+    Write-Host 'Provide values via CLI parameters or .agent-loop.json next to the script and/or in the working directory.' -ForegroundColor Yellow
     Write-Host 'See .agent-loop.example.json for the full schema.' -ForegroundColor Yellow
     exit 1
 }
 
 # ── Validate provider value ───────────────────────────────────────────
 if ($resolvedProvider -notin @('claude-code', 'cursor-cli')) {
-    Write-Host "Error: Invalid provider '$resolvedProvider'. Must be 'claude-code' or 'cursor-cli'." -ForegroundColor Red
+    Write-Host "Error: Invalid provider '$resolvedProvider'. Must be 'claude-code', 'cursor', or 'cursor-cli'." -ForegroundColor Red
     exit 1
 }
 
@@ -218,12 +323,18 @@ if (-not $env:AZURE_DEVOPS_PAT) {
     $envErrors.Add('Missing required environment variable: AZURE_DEVOPS_PAT')
 }
 
-if ($resolvedProvider -eq 'claude-code' -and -not $env:ANTHROPIC_API_KEY) {
-    $envErrors.Add('Missing required environment variable: ANTHROPIC_API_KEY (required for provider=claude-code)')
+if ($resolvedProvider -eq 'claude-code') {
+    if ($env:ANTHROPIC_API_KEY) {
+        log_warn 'ANTHROPIC_API_KEY is set; Claude Code will use API-key auth instead of the signed-in Claude session.'
+    } elseif ($env:CLAUDE_CODE_OAUTH_TOKEN) {
+        log_info 'CLAUDE_CODE_OAUTH_TOKEN detected; Claude Code will use OAuth token auth.'
+    } else {
+        log_info 'Claude Code will use the signed-in Claude session. Run `claude` and complete login first if needed.'
+    }
 }
 
 if ($resolvedProvider -eq 'cursor-cli' -and -not $env:CURSOR_API_KEY) {
-    $envErrors.Add('Missing required environment variable: CURSOR_API_KEY (required for provider=cursor-cli)')
+    log_info 'CURSOR_API_KEY not set; Cursor Agent will use the signed-in Cursor session.'
 }
 
 if ($envErrors.Count -gt 0) {
@@ -336,7 +447,7 @@ function Start-FeatureLog {
         "Feature Title: $FeatureTitle"
         "Started At (UTC): $((Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss'))"
         "Working Directory: $resolvedWorkingDir"
-        "Provider: $resolvedProvider$((if ($resolvedModel) { " ($resolvedModel)" } else { '' }))"
+        "Provider: $resolvedProvider$(if ($resolvedModel) { " ($resolvedModel)" } else { '' })"
         ''
     ) | Set-Content -Path $script:currentFeatureLogFile
     log_info "Persistent agent log: $($script:currentFeatureLogFile)"
@@ -379,7 +490,15 @@ function Invoke-AdoApi {
         'Authorization' = Get-AdoAuthHeader
         'Content-Type'  = $ContentType
     }
+    $previousProgressPreference = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
     try {
+        if ($Body) {
+            log_info "ADO request: Invoke-RestMethod -Method $Method -Uri '$Url' -ContentType '$ContentType' -Body $Body"
+        } else {
+            log_info "ADO request: Invoke-RestMethod -Method $Method -Uri '$Url' -ContentType '$ContentType'"
+        }
+
         if ($Body) {
             return Invoke-RestMethod -Method $Method -Uri $Url -Headers $headers -Body $Body
         } else {
@@ -391,7 +510,28 @@ function Invoke-AdoApi {
         log_error "ADO API error: HTTP $statusCode — $Method $Url"
         log_error "Response: $errorBody"
         throw
+    } finally {
+        $ProgressPreference = $previousProgressPreference
     }
+}
+
+function Get-WorkItemFieldValue {
+    param(
+        $Fields,
+        [string] $FieldName,
+        $DefaultValue = ''
+    )
+
+    if ($null -eq $Fields) {
+        return $DefaultValue
+    }
+
+    $property = $Fields.PSObject.Properties[$FieldName]
+    if ($null -eq $property -or $null -eq $property.Value) {
+        return $DefaultValue
+    }
+
+    return $property.Value
 }
 
 # Queries ADO for Features that have at least one child PBI tagged
@@ -461,10 +601,11 @@ function Get-WorkItem {
 
 # Transitions a work item to the given state.
 # Returns the "in progress" state name for the configured process template.
-# Scrum → "In Progress"; Agile/CMMI → "Active"; unknown → "In Progress".
+# Scrum PBIs → "Committed"; Agile/CMMI PBIs → "Active"; unknown → "In Progress".
 function Get-InProgressState {
     switch ($resolvedProcess) {
-        { $_ -in @('Agile', 'CMMI') } { return 'Active' }
+        'Scrum'                        { return 'Committed' }
+        { $_ -in @('Agile', 'CMMI') }  { return 'Active' }
         default                        { return 'In Progress' }
     }
 }
@@ -477,12 +618,31 @@ function Update-WorkItemState {
         [string] $WorkItemId,
         [string] $State
     )
-    $patchDoc = @(
+    $currentWorkItem = Get-WorkItem -WorkItemId $WorkItemId
+    $currentState = Get-WorkItemFieldValue -Fields $currentWorkItem.fields -FieldName 'System.State' -DefaultValue ''
+    if ($currentState -eq $State) {
+        log_info "Work item $WorkItemId is already in state '$State'"
+        return
+    }
+
+    $patchDoc = ConvertTo-Json -InputObject @(
         @{ op = 'replace'; path = '/fields/System.State'; value = $State }
-    ) | ConvertTo-Json -Compress
+    ) -Compress
     $url = "$resolvedOrg/$resolvedProject/_apis/wit/workitems/${WorkItemId}?api-version=7.1"
-    Invoke-AdoApi -Method PATCH -Url $url -Body $patchDoc -ContentType 'application/json-patch+json' | Out-Null
-    log_info "Work item $WorkItemId state set to '$State'"
+
+    try {
+        Invoke-AdoApi -Method PATCH -Url $url -Body $patchDoc -ContentType 'application/json-patch+json' | Out-Null
+        log_info "Work item $WorkItemId state set to '$State'"
+    } catch {
+        $refreshedWorkItem = Get-WorkItem -WorkItemId $WorkItemId
+        $refreshedState = Get-WorkItemFieldValue -Fields $refreshedWorkItem.fields -FieldName 'System.State' -DefaultValue ''
+        if ($refreshedState -eq $State) {
+            log_warn "Work item $WorkItemId was updated to '$State' by another process; continuing"
+            return
+        }
+
+        throw
+    }
 }
 
 # Appends a tag to a work item without removing existing tags.
@@ -494,7 +654,7 @@ function Add-WorkItemTag {
     )
     # Fetch current tags so we can append rather than overwrite.
     $workItem    = Get-WorkItem -WorkItemId $WorkItemId
-    $currentTags = $workItem.fields.'System.Tags'
+    $currentTags = Get-WorkItemFieldValue -Fields $workItem.fields -FieldName 'System.Tags' -DefaultValue ''
     $tagList     = if ($currentTags) { @($currentTags -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }) } else { @() }
     if ($tagList -contains $Tag) {
         log_info "Tag '$Tag' already present on work item $WorkItemId"
@@ -503,9 +663,9 @@ function Add-WorkItemTag {
     $newTags     = if ($currentTags) { "$currentTags; $Tag" } else { $Tag }
     $op          = if ($currentTags) { 'replace' } else { 'add' }
 
-    $patchDoc = @(
+    $patchDoc = ConvertTo-Json -InputObject @(
         @{ op = $op; path = '/fields/System.Tags'; value = $newTags }
-    ) | ConvertTo-Json -Compress
+    ) -Compress
     $url = "$resolvedOrg/$resolvedProject/_apis/wit/workitems/${WorkItemId}?api-version=7.1"
     Invoke-AdoApi -Method PATCH -Url $url -Body $patchDoc -ContentType 'application/json-patch+json' | Out-Null
     log_info "Tag '$Tag' appended to work item $WorkItemId"
@@ -524,18 +684,70 @@ function New-PullRequest {
         [object[]] $Pbis
     )
 
-    if (-not $resolvedRepoUrl) {
-        log_error "New-PullRequest: RepoUrl is not set — cannot determine repository for PR creation"
+    $repoUrlForPr = $resolvedRepoUrl
+
+    try {
+        Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'remote', 'get-url', 'origin')
+        $originRepoUrl = (git remote get-url origin 2>$null | Select-Object -First 1)
+        if ($LASTEXITCODE -eq 0 -and $originRepoUrl) {
+            $repoUrlForPr = $originRepoUrl.Trim()
+        }
+    } catch {
+        # Fall back to configured RepoUrl when git remote inspection fails.
+    }
+
+    if (-not $repoUrlForPr) {
+        log_error "New-PullRequest: RepoUrl is not set and origin remote could not be resolved"
         throw "RepoUrl is required for PR creation"
     }
 
-    # Extract repository name from RepoUrl (last path segment after /_git/).
-    $repoId = ($resolvedRepoUrl -split '/_git/')[-1] -replace '[/?].*', ''
-
-    if (-not $repoId) {
-        log_error "New-PullRequest: unable to parse repository name from RepoUrl='$resolvedRepoUrl'"
-        throw "Could not parse repository name from RepoUrl"
+    try {
+        $repoUri = [Uri]$repoUrlForPr
+    } catch {
+        log_error "New-PullRequest: RepoUrl '$repoUrlForPr' is not a valid absolute URI"
+        throw "Could not parse repository URL"
     }
+
+    $repoPathParts = @($repoUri.AbsolutePath.Trim('/') -split '/')
+    if ($repoPathParts.Count -lt 4 -or $repoPathParts[2] -ne '_git') {
+        log_error "New-PullRequest: unable to parse repository project/name from RepoUrl='$repoUrlForPr'"
+        throw "Could not parse repository project/name from RepoUrl"
+    }
+
+    $repoProject    = $repoPathParts[1]
+    $repoNameFromUrl = $repoPathParts[3]
+
+    if (-not $repoProject -or -not $repoNameFromUrl) {
+        log_error "New-PullRequest: parsed invalid repository context from RepoUrl='$repoUrlForPr'"
+        throw "Could not parse repository context from RepoUrl"
+    }
+
+    $repoProjectEscaped = [Uri]::EscapeDataString($repoProject)
+    $repoNameCandidates = @(
+        $repoNameFromUrl
+        ($repoNameFromUrl -replace '\.git$', '')
+    ) | Where-Object { $_ } | Select-Object -Unique
+
+    $repoListUrl = "$resolvedOrg/$repoProjectEscaped/_apis/git/repositories?api-version=7.1"
+    $repoList    = @(Invoke-AdoApi -Method GET -Url $repoListUrl).value
+    $repo        = $repoList | Where-Object {
+        $candidateNames = @(
+            [string]$_.name
+            (([string]$_.name) -replace '\.git$', '')
+        ) | Where-Object { $_ } | Select-Object -Unique
+
+        @($candidateNames | Where-Object { $repoNameCandidates -contains $_ }).Count -gt 0
+    } | Select-Object -First 1
+
+    if (-not $repo) {
+        log_error "New-PullRequest: unable to resolve repository metadata for RepoUrl='$repoUrlForPr'"
+        throw "Could not resolve repository metadata from RepoUrl"
+    }
+
+    $repoId         = [string]$repo.id
+    $repoName       = [string]$repo.name
+    $repoIdEscaped  = [Uri]::EscapeDataString($repoId)
+    $repoNameEscaped = [Uri]::EscapeDataString($repoName)
 
     # Build PR description listing all PBI IDs and titles.
     $descLines   = $Pbis | ForEach-Object { "- #$($_.id): $($_.fields.'System.Title')" }
@@ -552,11 +764,11 @@ function New-PullRequest {
         workItemRefs  = $workItemRefs
     } | ConvertTo-Json -Depth 5 -Compress
 
-    $url      = "$resolvedOrg/$resolvedProject/_apis/git/repositories/$repoId/pullrequests?api-version=7.1"
+    $url      = "$resolvedOrg/$repoProjectEscaped/_apis/git/repositories/$repoIdEscaped/pullrequests?api-version=7.1"
     $response = Invoke-AdoApi -Method POST -Url $url -Body $body
 
     $prId     = $response.pullRequestId
-    $prWebUrl = "$resolvedOrg/$resolvedProject/_git/$repoId/pullrequest/$prId"
+    $prWebUrl = "$resolvedOrg/$repoProjectEscaped/_git/$repoNameEscaped/pullrequest/$prId"
     log_info "Pull request #${prId} created: $prWebUrl"
     return $prWebUrl
 }
@@ -652,6 +864,7 @@ function Get-DefaultBranch {
         return $resolvedBaseBranch
     }
 
+    Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'symbolic-ref', 'refs/remotes/origin/HEAD')
     $ref = git symbolic-ref refs/remotes/origin/HEAD 2>$null
     if ($LASTEXITCODE -ne 0 -or -not $ref) {
         $msg = "Get-DefaultBranch: cannot determine default branch — set baseBranch in config or -BaseBranch"
@@ -692,6 +905,7 @@ function New-FeatureBranch {
 
     log_info "Creating branch '$branchName' from '$baseBranch'"
 
+    Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'fetch', 'origin', $baseBranch)
     git fetch origin $baseBranch 2>&1 | ForEach-Object { log_info "git: $_" }
     if ($LASTEXITCODE -ne 0) {
         $msg = "New-FeatureBranch: failed to fetch '$baseBranch' from origin"
@@ -700,11 +914,14 @@ function New-FeatureBranch {
     }
 
     # Check if branch already exists locally.
+    Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'show-ref', '--verify', '--quiet', "refs/heads/$branchName")
     git show-ref --verify --quiet "refs/heads/$branchName" 2>$null | Out-Null
     if ($LASTEXITCODE -eq 0) {
         log_info "Branch '$branchName' already exists locally — checking out"
+        Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'checkout', $branchName)
         git checkout $branchName 2>&1 | ForEach-Object { log_info "git: $_" }
     } else {
+        Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'checkout', '-b', $branchName, "origin/$baseBranch")
         git checkout -b $branchName "origin/$baseBranch" 2>&1 | ForEach-Object { log_info "git: $_" }
     }
     if ($LASTEXITCODE -ne 0) {
@@ -713,6 +930,7 @@ function New-FeatureBranch {
         throw $msg
     }
 
+    Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'push', '-u', 'origin', $branchName)
     git push -u origin $branchName 2>&1 | ForEach-Object { log_info "git: $_" }
     if ($LASTEXITCODE -ne 0) {
         $msg = "New-FeatureBranch: failed to push '$branchName' to origin"
@@ -731,6 +949,7 @@ function New-FeatureBranch {
 function Test-CleanAndPushed {
     param([string] $FeatureBranch)
 
+    Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'status', '--porcelain')
     $statusOutput = git status --porcelain 2>&1
     if ($statusOutput) {
         log_error "Test-CleanAndPushed: working tree is not clean — uncommitted changes detected"
@@ -739,8 +958,10 @@ function Test-CleanAndPushed {
     }
 
     # Fetch to make sure remote tracking ref is current.
+    Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'fetch', 'origin', $FeatureBranch)
     git fetch origin $FeatureBranch 2>$null | Out-Null
 
+    Write-CommandLog -Prefix 'Running:' -Arguments @('git', 'log', "origin/${FeatureBranch}..HEAD", '--oneline')
     $unpushed = git log "origin/${FeatureBranch}..HEAD" --oneline 2>&1
     if ($unpushed) {
         log_error "Test-CleanAndPushed: there are unpushed commits on '$FeatureBranch':"
@@ -792,6 +1013,83 @@ Read the file ```.agent-context/feature.md``` in your working directory for addi
 "@
 }
 
+# Recursively checks raw or JSON-parsed agent output for the exact
+# AGENT_COMPLETE token on its own line.
+function Test-AgentCompletionValue {
+    param($Value)
+
+    if ($null -eq $Value) {
+        return $false
+    }
+
+    if ($Value -is [string]) {
+        return [regex]::IsMatch($Value, '(?m)^\s*AGENT_COMPLETE\s*$')
+    }
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        foreach ($entry in $Value.GetEnumerator()) {
+            if (Test-AgentCompletionValue -Value $entry.Value) {
+                return $true
+            }
+        }
+
+        return $false
+    }
+
+    if (($Value -is [System.Collections.IEnumerable]) -and -not ($Value -is [string])) {
+        foreach ($item in $Value) {
+            if (Test-AgentCompletionValue -Value $item) {
+                return $true
+            }
+        }
+
+        return $false
+    }
+
+    foreach ($property in $Value.PSObject.Properties) {
+        if (Test-AgentCompletionValue -Value $property.Value) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+# Detects AGENT_COMPLETE in either raw text output or JSON output emitted by
+# Cursor/Claude CLIs when --output-format json is enabled.
+function Test-AgentCompleted {
+    param([string] $Output)
+
+    if (-not $Output) {
+        return $false
+    }
+
+    if (Test-AgentCompletionValue -Value $Output) {
+        return $true
+    }
+
+    $jsonCandidates = @($Output)
+    $jsonCandidates += @(
+        $Output -split '\r?\n' |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ }
+    )
+
+    foreach ($candidate in ($jsonCandidates | Select-Object -Unique)) {
+        try {
+            $parsed = $candidate | ConvertFrom-Json -Depth 100 -ErrorAction Stop
+        } catch {
+            continue
+        }
+
+        if (Test-AgentCompletionValue -Value $parsed) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 # Dispatches the configured AI provider with the given prompt and captures output.
 # Returns a hashtable with:
 #   ExitCode   — exit code from the agent process
@@ -820,8 +1118,14 @@ function Invoke-Agent {
             }
         }
         'cursor-cli' {
+            $modelArgs = if ($resolvedModel) { @('--model', $resolvedModel) } else { @() }
             try {
-                $output = & agent -p $Prompt --force --output-format json 2>&1 | Out-String
+                $output = & agent -p $Prompt `
+                    --force `
+                    --trust `
+                    --workspace $resolvedWorkingDir `
+                    --output-format json `
+                    @modelArgs 2>&1 | Out-String
                 $exitCode = $LASTEXITCODE
             } catch {
                 $output   = $_.Exception.Message
@@ -829,13 +1133,13 @@ function Invoke-Agent {
             }
         }
         default {
-            $msg = "Invoke-Agent: unknown provider '$resolvedProvider'. Must be 'claude-code' or 'cursor-cli'."
+            $msg = "Invoke-Agent: unknown provider '$resolvedProvider'. Must be 'claude-code', 'cursor', or 'cursor-cli'."
             log_error $msg
             throw $msg
         }
     }
 
-    $completed = $output -match '(?m)^AGENT_COMPLETE$'
+    $completed = Test-AgentCompleted -Output $output
 
     if ($exitCode -ne 0) {
         log_error "Invoke-Agent: agent exited with non-zero exit code $exitCode"
@@ -955,7 +1259,7 @@ try {
     }
 
     $featureTitle       = $featureJson.fields.'System.Title'
-    $featureDescription = $featureJson.fields.'System.Description'
+    $featureDescription = Get-WorkItemFieldValue -Fields $featureJson.fields -FieldName 'System.Description' -DefaultValue ''
 
     log_info "Processing Feature ${featureId}: $featureTitle"
     Start-FeatureLog -FeatureId $featureId -FeatureTitle $featureTitle
@@ -963,28 +1267,65 @@ try {
 
     # Step 5: Fetch all child PBIs
     log_info "Fetching child PBIs for Feature $featureId"
-    $pbis = @(Get-ChildPbis -FeatureId $featureId)
+    $allChildPbis = @(Get-ChildPbis -FeatureId $featureId)
 
-    # Filter to only PBIs tagged "ready-for-agent" in "New" state.
-    $pbis = @($pbis | Where-Object {
-        $tagList = if ($_.fields.'System.Tags') {
-            @($_.fields.'System.Tags' -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+    # Track all ready-for-agent PBIs for feature-level completion/PR creation,
+    # then separately derive the subset still pending and runnable.
+    $runnableStates = @('New', (Get-InProgressState))
+    $readyForAgentPbis = @($allChildPbis | Where-Object {
+        $tags = Get-WorkItemFieldValue -Fields $_.fields -FieldName 'System.Tags' -DefaultValue ''
+        $tagList = if ($tags) {
+            @($tags -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
         } else {
             @()
         }
-        $state = $_.fields.'System.State'
-        (($tagList -contains 'ready-for-agent') -and ($state -eq 'New'))
+        ($tagList -contains 'ready-for-agent')
     })
 
-    if ($pbis.Count -eq 0) {
-        log_info "Feature $featureId has no eligible child PBIs (ready-for-agent + New) — nothing to do"
+    if ($readyForAgentPbis.Count -eq 0) {
+        log_info "Feature $featureId has no ready-for-agent child PBIs — nothing to do"
         exit 0
     }
-    log_info "Found $($pbis.Count) eligible PBI(s) for Feature $featureId"
 
-    # Step 6: Topologically sort PBIs by dependency
-    log_info "Sorting PBIs by dependency order"
-    $sortedPbis = @(Sort-PbisByDependency -Pbis $pbis)
+    $remainingReadyForAgentPbis = @($readyForAgentPbis | Where-Object {
+        $tags = Get-WorkItemFieldValue -Fields $_.fields -FieldName 'System.Tags' -DefaultValue ''
+        $tagList = if ($tags) {
+            @($tags -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+        } else {
+            @()
+        }
+        (-not ($tagList -contains 'agent-done'))
+    })
+
+    $pbis = @($remainingReadyForAgentPbis | Where-Object {
+        $tags = Get-WorkItemFieldValue -Fields $_.fields -FieldName 'System.Tags' -DefaultValue ''
+        $tagList = if ($tags) {
+            @($tags -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+        } else {
+            @()
+        }
+        $state = Get-WorkItemFieldValue -Fields $_.fields -FieldName 'System.State' -DefaultValue ''
+        (($tagList -contains 'ready-for-agent') -and (-not ($tagList -contains 'agent-done')) -and ($runnableStates -contains $state))
+    })
+
+    log_info "Sorting PR PBIs by dependency order"
+    $prPbis = @(Sort-PbisByDependency -Pbis $readyForAgentPbis)
+
+    if ($pbis.Count -eq 0) {
+        if ($remainingReadyForAgentPbis.Count -eq 0) {
+            log_info "All ready-for-agent PBIs are already tagged agent-done — continuing to pull request creation"
+            $sortedPbis = @()
+        } else {
+            log_info "Feature $featureId has no eligible child PBIs (ready-for-agent + not agent-done + runnable state) — nothing to do"
+            exit 0
+        }
+    } else {
+        log_info "Found $($pbis.Count) eligible PBI(s) for Feature $featureId"
+
+        # Step 6: Topologically sort PBIs by dependency
+        log_info "Sorting PBIs by dependency order"
+        $sortedPbis = @(Sort-PbisByDependency -Pbis $pbis)
+    }
 
     # Step 7: Create feature branch
     log_info "Creating feature branch for Feature $featureId"
@@ -999,8 +1340,8 @@ try {
     foreach ($pbi in $sortedPbis) {
         $pbiId          = [string]$pbi.id
         $pbiTitle       = $pbi.fields.'System.Title'
-        $pbiDescription = $pbi.fields.'System.Description'
-        $pbiAc          = $pbi.fields.'Microsoft.VSTS.Common.AcceptanceCriteria'
+        $pbiDescription = Get-WorkItemFieldValue -Fields $pbi.fields -FieldName 'System.Description' -DefaultValue ''
+        $pbiAc          = Get-WorkItemFieldValue -Fields $pbi.fields -FieldName 'Microsoft.VSTS.Common.AcceptanceCriteria' -DefaultValue ''
 
         log_info "Starting PBI ${pbiId}: $pbiTitle"
 
@@ -1025,7 +1366,7 @@ try {
     if ($featureSuccess) {
         log_info "All PBIs completed — creating pull request for Feature $featureId"
         try {
-            $prUrl = New-PullRequest -FeatureTitle $featureTitle -FeatureBranch $featureBranch -Pbis $sortedPbis
+            $prUrl = New-PullRequest -FeatureTitle $featureTitle -FeatureBranch $featureBranch -Pbis $prPbis
         } catch {
             Add-FeatureLogNote -Message 'Failed to create pull request'
             throw

--- a/agent-loop/agent-loop.sh
+++ b/agent-loop/agent-loop.sh
@@ -62,7 +62,7 @@ Options:
   --repo-url <url>          Git repository URL
   --base-branch <branch>    Base branch (auto-detected from git if omitted)
   --max-iterations <n>      Max agent invocations per PBI (default: 5)
-  --provider <name>         AI provider: claude-code or cursor-cli
+  --provider <name>         AI provider: claude-code, cursor, or cursor-cli
   --model <id>              Model ID to use (e.g. claude-opus-4-6)
   --working-directory <dir> Working directory containing the repo
   --system-log-directory <dir>
@@ -71,8 +71,11 @@ Options:
 
 Environment variables:
   AZURE_DEVOPS_PAT          Required. Azure DevOps Personal Access Token.
-  ANTHROPIC_API_KEY         Required when --provider is claude-code.
-  CURSOR_API_KEY            Required when --provider is cursor-cli.
+  ANTHROPIC_API_KEY         Optional when --provider is claude-code;
+                            if set, Claude Code uses API-key auth instead of
+                            the signed-in Claude session.
+  CURSOR_API_KEY            Optional when --provider is cursor/cursor-cli;
+                            if omitted, the signed-in Cursor session is used.
 
 Config file:
   .agent-loop.json          Optional JSON config in the working directory.
@@ -95,6 +98,36 @@ resolve_system_log_directory() {
     Darwin) printf '%s\n' "${HOME}/Library/Logs/agent-loop" ;;
     Linux)  printf '%s\n' "${XDG_STATE_HOME:-${HOME}/.local/state}/agent-loop/logs" ;;
     *)      printf '%s\n' "${HOME}/.agent-loop/logs" ;;
+  esac
+}
+
+normalize_provider_name() {
+  local provider_value="$1"
+
+  case "${provider_value,,}" in
+    cursor|cursor-cli) printf '%s\n' "cursor-cli" ;;
+    claude-code) printf '%s\n' "claude-code" ;;
+    *) printf '%s\n' "$provider_value" ;;
+  esac
+}
+
+normalize_cursor_model() {
+  local provider_value="$1"
+  local model_value="$2"
+
+  if [ "$provider_value" != "cursor-cli" ] || [ -z "$model_value" ]; then
+    printf '%s\n' "$model_value"
+    return 0
+  fi
+
+  case "$model_value" in
+    claude-opus-4-6)
+      log_info "Normalizing Cursor model '$model_value' to 'claude-4.6-opus-high-thinking'."
+      printf '%s\n' "claude-4.6-opus-high-thinking"
+      ;;
+    *)
+      printf '%s\n' "$model_value"
+      ;;
   esac
 }
 
@@ -123,30 +156,43 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ── Load config file ──────────────────────────────────────────────────
-# Resolve working directory: CLI > env > current directory
-INITIAL_WORKING_DIR="${CLI_WORKING_DIRECTORY:-${AGENT_LOOP_WORKING_DIRECTORY:-$(pwd)}}"
-WORKING_DIR="$INITIAL_WORKING_DIR"
-CONFIG_FILE="$INITIAL_WORKING_DIR/.agent-loop.json"
+import_config_file() {
+  local config_file="$1"
 
-if [ -f "$CONFIG_FILE" ]; then
+  if [ ! -f "$config_file" ]; then
+    return 0
+  fi
+
   if ! command -v jq &>/dev/null; then
     echo "Error: jq is required to parse .agent-loop.json. Install with: brew install jq / sudo apt install jq" >&2
     exit 1
   fi
 
-  CONFIG_ORG=$(jq -r '.organizationUrl // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_PROJECT=$(jq -r '.project // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_AREA_PATH=$(jq -r '.areaPath // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_TEAM=$(jq -r '.team // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_PROCESS=$(jq -r '.process // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_REPO_URL=$(jq -r '.repositoryUrl // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_BASE_BRANCH=$(jq -r '.baseBranch // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_MAX_ITERATIONS=$(jq -r '.maxIterationsPerPbi // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_PROVIDER=$(jq -r '.provider // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_MODEL=$(jq -r '.model // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_WORKING_DIRECTORY=$(jq -r '.workingDirectory // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_SYSTEM_LOG_DIRECTORY=$(jq -r '.systemLogDirectory // empty' "$CONFIG_FILE" 2>/dev/null || true)
-  CONFIG_FEATURE_ID=$(jq -r '.featureId // empty' "$CONFIG_FILE" 2>/dev/null || true)
+  CONFIG_ORG=$(jq -r '.organizationUrl // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_PROJECT=$(jq -r '.project // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_AREA_PATH=$(jq -r '.areaPath // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_TEAM=$(jq -r '.team // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_PROCESS=$(jq -r '.process // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_REPO_URL=$(jq -r '.repositoryUrl // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_BASE_BRANCH=$(jq -r '.baseBranch // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_MAX_ITERATIONS=$(jq -r '.maxIterationsPerPbi // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_PROVIDER=$(jq -r '.provider // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_MODEL=$(jq -r '.model // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_WORKING_DIRECTORY=$(jq -r '.workingDirectory // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_SYSTEM_LOG_DIRECTORY=$(jq -r '.systemLogDirectory // empty' "$config_file" 2>/dev/null || true)
+  CONFIG_FEATURE_ID=$(jq -r '.featureId // empty' "$config_file" 2>/dev/null || true)
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_CONFIG_FILE="$SCRIPT_DIR/.agent-loop.json"
+import_config_file "$SCRIPT_CONFIG_FILE"
+
+CANDIDATE_WORKING_DIR="${CLI_WORKING_DIRECTORY:-${CONFIG_WORKING_DIRECTORY:-${AGENT_LOOP_WORKING_DIRECTORY:-$(pwd)}}}"
+if [ -n "$CANDIDATE_WORKING_DIR" ]; then
+  WORKING_CONFIG_FILE="$CANDIDATE_WORKING_DIR/.agent-loop.json"
+  if [ "$(cd "$(dirname "$WORKING_CONFIG_FILE")" 2>/dev/null && pwd)/$(basename "$WORKING_CONFIG_FILE")" != "$(cd "$(dirname "$SCRIPT_CONFIG_FILE")" 2>/dev/null && pwd)/$(basename "$SCRIPT_CONFIG_FILE")" ]; then
+    import_config_file "$WORKING_CONFIG_FILE"
+  fi
 fi
 
 # ── Merge: CLI wins over config file ─────────────────────────────────
@@ -158,18 +204,20 @@ PROCESS="${CLI_PROCESS:-$CONFIG_PROCESS}"
 REPO_URL="${CLI_REPO_URL:-$CONFIG_REPO_URL}"
 BASE_BRANCH="${CLI_BASE_BRANCH:-${CONFIG_BASE_BRANCH:-}}"
 MAX_ITERATIONS="${CLI_MAX_ITERATIONS:-${CONFIG_MAX_ITERATIONS:-5}}"
-PROVIDER="${CLI_PROVIDER:-$CONFIG_PROVIDER}"
+PROVIDER="$(normalize_provider_name "${CLI_PROVIDER:-$CONFIG_PROVIDER}")"
 MODEL="${CLI_MODEL:-$CONFIG_MODEL}"
 FEATURE_ID="${CLI_FEATURE_ID:-$CONFIG_FEATURE_ID}"
-WORKING_DIR="${CLI_WORKING_DIRECTORY:-${CONFIG_WORKING_DIRECTORY:-$INITIAL_WORKING_DIR}}"
+WORKING_DIR="${CLI_WORKING_DIRECTORY:-${CONFIG_WORKING_DIRECTORY:-${AGENT_LOOP_WORKING_DIRECTORY:-$(pwd)}}}"
 SYSTEM_LOG_DIR="${CLI_SYSTEM_LOG_DIRECTORY:-${CONFIG_SYSTEM_LOG_DIRECTORY:-${AGENT_LOOP_SYSTEM_LOG_DIR:-$(resolve_system_log_directory)}}}"
+
+MODEL="$(normalize_cursor_model "$PROVIDER" "$MODEL")"
 
 # ── Validate required values ──────────────────────────────────────────
 ERRORS=()
 
 [ -z "$ORG" ]      && ERRORS+=("Missing required value: --org (Azure DevOps org URL)")
 [ -z "$PROJECT" ]  && ERRORS+=("Missing required value: --project (Azure DevOps project name)")
-[ -z "$PROVIDER" ] && ERRORS+=("Missing required value: --provider (claude-code or cursor-cli)")
+[ -z "$PROVIDER" ] && ERRORS+=("Missing required value: --provider (claude-code, cursor, or cursor-cli)")
 
 if [ ${#ERRORS[@]} -gt 0 ]; then
   echo "Error: Configuration is incomplete:" >&2
@@ -184,7 +232,7 @@ fi
 
 # ── Validate provider value ───────────────────────────────────────────
 if [[ "$PROVIDER" != "claude-code" && "$PROVIDER" != "cursor-cli" ]]; then
-  echo "Error: Invalid provider '$PROVIDER'. Must be 'claude-code' or 'cursor-cli'." >&2
+  echo "Error: Invalid provider '$PROVIDER'. Must be 'claude-code', 'cursor', or 'cursor-cli'." >&2
   exit 1
 fi
 
@@ -210,12 +258,18 @@ if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
   ENV_ERRORS+=("Missing required environment variable: AZURE_DEVOPS_PAT")
 fi
 
-if [ "$PROVIDER" = "claude-code" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-  ENV_ERRORS+=("Missing required environment variable: ANTHROPIC_API_KEY (required for provider=claude-code)")
+if [ "$PROVIDER" = "claude-code" ]; then
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    log_warn "ANTHROPIC_API_KEY is set; Claude Code will use API-key auth instead of the signed-in Claude session."
+  elif [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+    log_info "CLAUDE_CODE_OAUTH_TOKEN detected; Claude Code will use OAuth token auth."
+  else
+    log_info "Claude Code will use the signed-in Claude session. Run 'claude' and complete login first if needed."
+  fi
 fi
 
 if [ "$PROVIDER" = "cursor-cli" ] && [ -z "${CURSOR_API_KEY:-}" ]; then
-  ENV_ERRORS+=("Missing required environment variable: CURSOR_API_KEY (required for provider=cursor-cli)")
+  log_info "CURSOR_API_KEY not set; Cursor Agent will use the signed-in Cursor session."
 fi
 
 if [ ${#ENV_ERRORS[@]} -gt 0 ]; then
@@ -457,9 +511,10 @@ get_work_item() {
 }
 
 # Returns the "in progress" state name for the configured process template.
-# Scrum → "In Progress"; Agile/CMMI → "Active"; unknown → "In Progress".
+# Scrum → "Committed"; Agile/CMMI → "Active"; unknown → "In Progress".
 get_in_progress_state() {
   case "${PROCESS:-}" in
+    Scrum)      echo "Committed" ;;
     Agile|CMMI) echo "Active" ;;
     *)          echo "In Progress" ;;
   esac
@@ -473,11 +528,33 @@ update_work_item_state() {
   local work_item_id="$1"
   local state="$2"
 
+  local current_work_item
+  current_work_item=$(get_work_item "$work_item_id") || return 1
+
+  local current_state
+  current_state=$(printf '%s' "$current_work_item" | jq -r '.fields["System.State"] // ""')
+  if [ "$current_state" = "$state" ]; then
+    log_info "Work item $work_item_id is already in state '$state'"
+    return 0
+  fi
+
   local payload
   payload=$(jq -n --arg s "$state" '[{"op":"replace","path":"/fields/System.State","value":$s}]')
 
   local url="${ORG}/${PROJECT}/_apis/wit/workitems/${work_item_id}?api-version=7.1"
-  _ado_call PATCH "$url" "$payload" "application/json-patch+json" || return 1
+  if ! _ado_call PATCH "$url" "$payload" "application/json-patch+json" >/dev/null; then
+    local refreshed_work_item
+    refreshed_work_item=$(get_work_item "$work_item_id") || return 1
+
+    local refreshed_state
+    refreshed_state=$(printf '%s' "$refreshed_work_item" | jq -r '.fields["System.State"] // ""')
+    if [ "$refreshed_state" = "$state" ]; then
+      log_warn "Work item $work_item_id was updated to '$state' by another process; continuing"
+      return 0
+    fi
+
+    return 1
+  fi
   log_info "Work item $work_item_id state set to '$state'"
 }
 
@@ -526,18 +603,72 @@ create_pull_request() {
   local feature_title="$1"
   local feature_branch="$2"
   local pbis_json="$3"
+  local repo_url_for_pr="$REPO_URL"
 
-  if [ -z "$REPO_URL" ]; then
-    log_error "create_pull_request: REPO_URL is not set — cannot determine repository for PR creation"
+  local origin_repo_url=""
+  if origin_repo_url=$(git remote get-url origin 2>/dev/null); then
+    origin_repo_url="${origin_repo_url%%$'\n'*}"
+    if [ -n "$origin_repo_url" ]; then
+      repo_url_for_pr="$origin_repo_url"
+    fi
+  fi
+
+  if [ -z "$repo_url_for_pr" ]; then
+    log_error "create_pull_request: REPO_URL is not set and origin remote could not be resolved"
     return 1
   fi
 
-  # Extract repository name from REPO_URL (last path segment after /_git/).
-  local repo_id
-  repo_id=$(printf '%s' "$REPO_URL" | sed 's|.*/_git/||' | sed 's|[/?].*||')
+  local repo_path
+  repo_path=$(printf '%s' "$repo_url_for_pr" | sed -E 's|^[^:]+://[^/]+||; s|^[^@]+@[^:]+:|/|')
+  repo_path="${repo_path#/}"
+  repo_path="${repo_path%%\?*}"
 
-  if [ -z "$repo_id" ]; then
-    log_error "create_pull_request: unable to parse repository name from REPO_URL='$REPO_URL'"
+  IFS='/' read -r -a repo_path_parts <<< "$repo_path"
+  if [ "${#repo_path_parts[@]}" -lt 4 ] || [ "${repo_path_parts[2]}" != "_git" ]; then
+    log_error "create_pull_request: unable to parse repository project/name from REPO_URL='$repo_url_for_pr'"
+    return 1
+  fi
+
+  local repo_project="${repo_path_parts[1]}"
+  local repo_name_from_url="${repo_path_parts[3]}"
+  if [ -z "$repo_project" ] || [ -z "$repo_name_from_url" ]; then
+    log_error "create_pull_request: parsed invalid repository context from REPO_URL='$repo_url_for_pr'"
+    return 1
+  fi
+
+  local repo_list_url="${ORG}/${repo_project}/_apis/git/repositories?api-version=7.1"
+  local repo_list_json
+  repo_list_json=$(_ado_call GET "$repo_list_url") || return 1
+
+  local repo_name_candidates_json
+  repo_name_candidates_json=$(jq -n \
+    --arg repoName "$repo_name_from_url" \
+    '[$repoName, ($repoName | sub("\\.git$"; ""))] | map(select(length > 0)) | unique')
+
+  local repo_json
+  repo_json=$(printf '%s' "$repo_list_json" | jq -c \
+    --argjson names "$repo_name_candidates_json" '
+      (.value // [])
+      | map(
+          . as $repo
+          | (($names | index($repo.name)) != null
+             or ($names | index(($repo.name | sub("\\.git$"; "")))) != null)
+          | select(.)
+          | $repo
+        )
+      | .[0] // empty
+    ')
+
+  if [ -z "$repo_json" ]; then
+    log_error "create_pull_request: unable to resolve repository metadata for REPO_URL='$repo_url_for_pr'"
+    return 1
+  fi
+
+  local repo_id repo_name
+  repo_id=$(printf '%s' "$repo_json" | jq -r '.id // empty')
+  repo_name=$(printf '%s' "$repo_json" | jq -r '.name // empty')
+  if [ -z "$repo_id" ] || [ -z "$repo_name" ]; then
+    log_error "create_pull_request: could not parse repository metadata from REPO_URL='$repo_url_for_pr'"
     return 1
   fi
 
@@ -567,7 +698,7 @@ create_pull_request() {
       "workItemRefs":  $wir
     }')
 
-  local url="${ORG}/${PROJECT}/_apis/git/repositories/${repo_id}/pullrequests?api-version=7.1"
+  local url="${ORG}/${repo_project}/_apis/git/repositories/${repo_id}/pullrequests?api-version=7.1"
   local response
   response=$(_ado_call POST "$url" "$payload") || {
     log_error "create_pull_request: failed to create PR for branch '$feature_branch'"
@@ -582,7 +713,7 @@ create_pull_request() {
     return 1
   fi
 
-  local pr_web_url="${ORG}/${PROJECT}/_git/${repo_id}/pullrequest/${pr_id}"
+  local pr_web_url="${ORG}/${repo_project}/_git/${repo_name}/pullrequest/${pr_id}"
   log_info "Pull request #${pr_id} created: $pr_web_url"
   printf '%s\n' "$pr_web_url"
 }
@@ -854,6 +985,47 @@ invoke_agent() {
   AGENT_INVOKE_EXIT_CODE=0
   AGENT_INVOKE_COMPLETED="false"
 
+  test_agent_completion_value() {
+    local input="$1"
+
+    if [ -z "$input" ]; then
+      return 1
+    fi
+
+    if printf '%s\n' "$input" | grep -Eq '^[[:space:]]*AGENT_COMPLETE[[:space:]]*$'; then
+      return 0
+    fi
+
+    if printf '%s' "$input" | jq -e '
+      def contains_completion:
+        if type == "string" then test("(?m)^\\s*AGENT_COMPLETE\\s*$")
+        elif type == "array" then any(.[]; contains_completion)
+        elif type == "object" then any(.[]; contains_completion)
+        else false
+        end;
+      contains_completion
+    ' >/dev/null 2>&1; then
+      return 0
+    fi
+
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      if printf '%s' "$line" | jq -e '
+        def contains_completion:
+          if type == "string" then test("(?m)^\\s*AGENT_COMPLETE\\s*$")
+          elif type == "array" then any(.[]; contains_completion)
+          elif type == "object" then any(.[]; contains_completion)
+          else false
+          end;
+        contains_completion
+      ' >/dev/null 2>&1; then
+        return 0
+      fi
+    done <<< "$input"
+
+    return 1
+  }
+
   case "$PROVIDER" in
     claude-code)
       local model_args=()
@@ -866,17 +1038,26 @@ invoke_agent() {
         --allowedTools "Read,Write,Edit,Bash" 2>&1) || exit_code=$?
       ;;
     cursor-cli)
-      output=$(agent -p "$prompt" --force --output-format json 2>&1) || exit_code=$?
+      local model_args=()
+      if [ -n "$MODEL" ]; then
+        model_args=(--model "$MODEL")
+      fi
+      output=$(agent -p "$prompt" \
+        --force \
+        --trust \
+        --workspace "$WORKING_DIR" \
+        --output-format json \
+        "${model_args[@]}" 2>&1) || exit_code=$?
       ;;
     *)
-      log_error "invoke_agent: unknown provider '$PROVIDER'. Must be 'claude-code' or 'cursor-cli'."
+      log_error "invoke_agent: unknown provider '$PROVIDER'. Must be 'claude-code', 'cursor', or 'cursor-cli'."
       return 1
       ;;
   esac
 
   AGENT_INVOKE_EXIT_CODE=$exit_code
 
-  if printf '%s\n' "$output" | grep -qx 'AGENT_COMPLETE'; then
+  if test_agent_completion_value "$output"; then
     AGENT_INVOKE_COMPLETED="true"
   fi
 
@@ -1008,28 +1189,66 @@ PBIS_JSON=$(get_child_pbis "$FEATURE_ID") || {
   exit 1
 }
 
-# Filter to only PBIs tagged "ready-for-agent" in "New" state.
-PBIS_JSON=$(printf '%s' "$PBIS_JSON" | jq '[.[] | select(
+runnable_state=$(get_in_progress_state)
+READY_FOR_AGENT_PBIS=$(printf '%s' "$PBIS_JSON" | jq '[.[] | select(
   ((.fields["System.Tags"] // "")
     | split(";")
     | map(gsub("^\\s+|\\s+$"; ""))
     | any(. == "ready-for-agent"))
-  and .fields["System.State"] == "New"
 )]')
+
+READY_FOR_AGENT_COUNT=$(printf '%s' "$READY_FOR_AGENT_PBIS" | jq 'length')
+if [ "$READY_FOR_AGENT_COUNT" -eq 0 ]; then
+  log_info "Feature $FEATURE_ID has no ready-for-agent child PBIs — nothing to do"
+  exit 0
+fi
+
+REMAINING_READY_FOR_AGENT_PBIS=$(printf '%s' "$READY_FOR_AGENT_PBIS" | jq '[.[] | select(
+  ((.fields["System.Tags"] // "")
+    | split(";")
+    | map(gsub("^\\s+|\\s+$"; ""))
+    | any(. == "agent-done")) | not
+)]')
+
+PBIS_JSON=$(printf '%s' "$REMAINING_READY_FOR_AGENT_PBIS" | jq \
+  --arg runnable_state "$runnable_state" '[.[] | select(
+    ((.fields["System.Tags"] // "")
+      | split(";")
+      | map(gsub("^\\s+|\\s+$"; ""))
+      | any(. == "ready-for-agent"))
+    and (((.fields["System.Tags"] // "")
+      | split(";")
+      | map(gsub("^\\s+|\\s+$"; ""))
+      | any(. == "agent-done")) | not)
+    and ((.fields["System.State"] // "") == "New" or (.fields["System.State"] // "") == $runnable_state)
+  )]')
+
+log_info "Sorting PR PBIs by dependency order"
+PR_PBIS=$(sort_pbis_by_dependency "$READY_FOR_AGENT_PBIS") || {
+  log_error "Failed to sort PR PBIs by dependency for Feature $FEATURE_ID"
+  exit 1
+}
 
 PBI_COUNT=$(printf '%s' "$PBIS_JSON" | jq 'length')
 if [ "$PBI_COUNT" -eq 0 ]; then
-  log_info "Feature $FEATURE_ID has no eligible child PBIs (ready-for-agent + New) — nothing to do"
-  exit 0
-fi
-log_info "Found $PBI_COUNT eligible PBI(s) for Feature $FEATURE_ID"
+  REMAINING_READY_COUNT=$(printf '%s' "$REMAINING_READY_FOR_AGENT_PBIS" | jq 'length')
+  if [ "$REMAINING_READY_COUNT" -eq 0 ]; then
+    log_info "All ready-for-agent PBIs are already tagged agent-done — continuing to pull request creation"
+    SORTED_PBIS='[]'
+  else
+    log_info "Feature $FEATURE_ID has no eligible child PBIs (ready-for-agent + not agent-done + runnable state) — nothing to do"
+    exit 0
+  fi
+else
+  log_info "Found $PBI_COUNT eligible PBI(s) for Feature $FEATURE_ID"
 
-# Step 6: Topologically sort PBIs by dependency
-log_info "Sorting PBIs by dependency order"
-SORTED_PBIS=$(sort_pbis_by_dependency "$PBIS_JSON") || {
-  log_error "Failed to sort PBIs by dependency for Feature $FEATURE_ID"
-  exit 1
-}
+  # Step 6: Topologically sort PBIs by dependency
+  log_info "Sorting PBIs by dependency order"
+  SORTED_PBIS=$(sort_pbis_by_dependency "$PBIS_JSON") || {
+    log_error "Failed to sort PBIs by dependency for Feature $FEATURE_ID"
+    exit 1
+  }
+fi
 
 # Step 7: Create feature branch
 log_info "Creating feature branch for Feature $FEATURE_ID"
@@ -1046,28 +1265,30 @@ $FEATURE_DESCRIPTION"
 
 # Step 9/10: Process each PBI serially; stop on first failure
 FEATURE_SUCCESS=true
-for i in $(seq 0 $((PBI_COUNT - 1))); do
-  PBI_JSON=$(printf '%s' "$SORTED_PBIS" | jq ".[$i]")
-  PBI_ID=$(printf '%s' "$PBI_JSON" | jq -r '.id')
-  PBI_TITLE=$(printf '%s' "$PBI_JSON" | jq -r '.fields["System.Title"] // ""')
-  PBI_DESCRIPTION=$(printf '%s' "$PBI_JSON" | jq -r '.fields["System.Description"] // ""')
-  PBI_AC=$(printf '%s' "$PBI_JSON" | jq -r '.fields["Microsoft.VSTS.Common.AcceptanceCriteria"] // ""')
+if [ "$PBI_COUNT" -gt 0 ]; then
+  for i in $(seq 0 $((PBI_COUNT - 1))); do
+    PBI_JSON=$(printf '%s' "$SORTED_PBIS" | jq ".[$i]")
+    PBI_ID=$(printf '%s' "$PBI_JSON" | jq -r '.id')
+    PBI_TITLE=$(printf '%s' "$PBI_JSON" | jq -r '.fields["System.Title"] // ""')
+    PBI_DESCRIPTION=$(printf '%s' "$PBI_JSON" | jq -r '.fields["System.Description"] // ""')
+    PBI_AC=$(printf '%s' "$PBI_JSON" | jq -r '.fields["Microsoft.VSTS.Common.AcceptanceCriteria"] // ""')
 
-  log_info "Starting PBI $PBI_ID: $PBI_TITLE"
+    log_info "Starting PBI $PBI_ID: $PBI_TITLE"
 
-  if ! process_pbi "$PBI_ID" "$PBI_TITLE" "$PBI_DESCRIPTION" "$PBI_AC" "$FEATURE_BRANCH" "$FEATURE_ID"; then
-    log_error "PBI $PBI_ID failed — skipping remaining PBIs for Feature $FEATURE_ID"
-    FEATURE_SUCCESS=false
-    break
-  fi
+    if ! process_pbi "$PBI_ID" "$PBI_TITLE" "$PBI_DESCRIPTION" "$PBI_AC" "$FEATURE_BRANCH" "$FEATURE_ID"; then
+      log_error "PBI $PBI_ID failed — skipping remaining PBIs for Feature $FEATURE_ID"
+      FEATURE_SUCCESS=false
+      break
+    fi
 
-  log_info "PBI $PBI_ID completed"
-done
+    log_info "PBI $PBI_ID completed"
+  done
+fi
 
 # Step 11: Create PR only when all PBIs are tagged agent-done
 if [ "$FEATURE_SUCCESS" = "true" ]; then
   log_info "All PBIs completed — creating pull request for Feature $FEATURE_ID"
-  PR_URL=$(create_pull_request "$FEATURE_TITLE" "$FEATURE_BRANCH" "$SORTED_PBIS") || {
+  PR_URL=$(create_pull_request "$FEATURE_TITLE" "$FEATURE_BRANCH" "$PR_PBIS") || {
     log_error "Failed to create pull request for Feature $FEATURE_ID"
     append_feature_log_note "Failed to create pull request"
     exit 1


### PR DESCRIPTION
## Summary
- tighten the `agent-loop` PowerShell and Bash flows so reruns behave correctly: skip already-completed PBIs, accept runnable in-progress states, and avoid failing when a work item was already moved to the target state
- make provider and repository handling more resilient by supporting the `cursor` alias, improving config/repo resolution, and fixing pull request creation when `repositoryUrl` is omitted but `origin` is available
- improve operability with better command/config logging and update the README to explain Claude Code signed-in auth vs `ANTHROPIC_API_KEY` usage

## Test plan
- Not run here; please exercise the updated `agent-loop.sh` and `agent-loop.ps1` flows manually
- Validate PR creation still works with and without an explicit `repositoryUrl`
- Validate a rerun on a Feature with already `agent-done` PBIs skips completed work and still reaches PR creation when appropriate

Made with [Cursor](https://cursor.com)